### PR TITLE
End mission on all players leaving when Headless Clients are present

### DIFF
--- a/addons/headless/ACE_Settings.hpp
+++ b/addons/headless/ACE_Settings.hpp
@@ -11,6 +11,12 @@ class ACE_Settings {
         displayName = CSTRING(Delay);
         description = CSTRING(DelayDesc);
     };
+    class GVAR(EndMission) {
+        value = 0;
+        typeName = "BOOL";
+        displayName = CSTRING(EndMission);
+        description = CSTRING(EndMissionDesc);
+    };
     class GVAR(Log) {
         value = 0;
         typeName = "BOOL";

--- a/addons/headless/ACE_Settings.hpp
+++ b/addons/headless/ACE_Settings.hpp
@@ -1,24 +1,24 @@
 class ACE_Settings {
-    class GVAR(Enabled) {
+    class GVAR(enabled) {
         value = 0;
         typeName = "BOOL";
         displayName = ACECSTRING(common,Enabled);
         description = CSTRING(EnabledDesc);
     };
-    class GVAR(Delay) {
+    class GVAR(delay) {
         value = DELAY_DEFAULT;
         typeName = "SCALAR";
         displayName = CSTRING(Delay);
         description = CSTRING(DelayDesc);
     };
-    class GVAR(EndMission) {
+    class GVAR(endMission) {
         value = 0;
         values[] = {ACECSTRING(Common,Disabled), CSTRING(Instant), CSTRING(Delayed)};
         typeName = "SCALAR";
         displayName = CSTRING(EndMission);
         description = CSTRING(EndMissionDesc);
     };
-    class GVAR(Log) {
+    class GVAR(log) {
         value = 0;
         typeName = "BOOL";
         displayName = CSTRING(Log);

--- a/addons/headless/ACE_Settings.hpp
+++ b/addons/headless/ACE_Settings.hpp
@@ -13,7 +13,8 @@ class ACE_Settings {
     };
     class GVAR(EndMission) {
         value = 0;
-        typeName = "BOOL";
+        values[] = {ACECSTRING(Common,Disabled), CSTRING(Instant), CSTRING(Delayed)};
+        typeName = "SCALAR";
         displayName = CSTRING(EndMission);
         description = CSTRING(EndMissionDesc);
     };

--- a/addons/headless/CfgVehicles.hpp
+++ b/addons/headless/CfgVehicles.hpp
@@ -26,8 +26,22 @@ class CfgVehicles {
             class EndMission {
                 displayName = CSTRING(EndMission);
                 description = CSTRING(EndMissionDesc);
-                typeName = "BOOL";
-                defaultValue = 0;
+                typeName = "NUMBER";
+                class values {
+                    class Disabled {
+                        name = ACECSTRING(Common,Disabled);
+                        value = 0;
+                        default = 1;
+                    };
+                    class Instant {
+                        name = CSTRING(Instant);
+                        value = 1;
+                    };
+                    class Delayed {
+                        name = CSTRING(Delayed);
+                        value = 2;
+                    };
+                };
             };
             class Log {
                 displayName = CSTRING(Log);

--- a/addons/headless/CfgVehicles.hpp
+++ b/addons/headless/CfgVehicles.hpp
@@ -2,6 +2,7 @@ class CfgVehicles {
     class ACE_Module;
     class GVAR(module): ACE_Module {
         author = "$STR_ACE_common_ACETeam";
+        author = ACECSTRING(common,ACETeam);
         category = "ACEX";
         displayName = CSTRING(Module);
         function = QFUNC(moduleInit);
@@ -9,7 +10,7 @@ class CfgVehicles {
         isGlobal = 1; // Global
         isTriggerActivated = 0;
         isDisposable = 0;
-        icon = QUOTE(PATHTOF(UI\Icon_Module_Headless_ca.paa));
+        icon = QPATHTOF(UI\Icon_Module_Headless_ca.paa);
         class Arguments {
             class Enabled {
                 displayName = ACECSTRING(common,Enabled);
@@ -22,6 +23,12 @@ class CfgVehicles {
                 description = CSTRING(DelayDesc);
                 typeName = "NUMBER";
                 defaultValue = DELAY_DEFAULT;
+            };
+            class EndMission {
+                displayName = CSTRING(EndMission);
+                description = CSTRING(EndMissionDesc);
+                typeName = "BOOL";
+                defaultValue = 0;
             };
             class Log {
                 displayName = CSTRING(Log);

--- a/addons/headless/CfgVehicles.hpp
+++ b/addons/headless/CfgVehicles.hpp
@@ -11,39 +11,39 @@ class CfgVehicles {
         isDisposable = 0;
         icon = QPATHTOF(UI\Icon_Module_Headless_ca.paa);
         class Arguments {
-            class Enabled {
+            class enabled {
                 displayName = ACECSTRING(common,Enabled);
                 description = CSTRING(EnabledDesc);
                 typeName = "BOOL";
                 defaultValue = 0;
             };
-            class Delay {
+            class delay {
                 displayName = CSTRING(Delay);
                 description = CSTRING(DelayDesc);
                 typeName = "NUMBER";
                 defaultValue = DELAY_DEFAULT;
             };
-            class EndMission {
+            class endMission {
                 displayName = CSTRING(EndMission);
                 description = CSTRING(EndMissionDesc);
                 typeName = "NUMBER";
                 class values {
-                    class Disabled {
+                    class disabled {
                         name = ACECSTRING(Common,Disabled);
                         value = 0;
                         default = 1;
                     };
-                    class Instant {
+                    class instant {
                         name = CSTRING(Instant);
                         value = 1;
                     };
-                    class Delayed {
+                    class delayed {
                         name = CSTRING(Delayed);
                         value = 2;
                     };
                 };
             };
-            class Log {
+            class log {
                 displayName = CSTRING(Log);
                 description = CSTRING(LogDesc);
                 typeName = "BOOL";

--- a/addons/headless/CfgVehicles.hpp
+++ b/addons/headless/CfgVehicles.hpp
@@ -1,7 +1,6 @@
 class CfgVehicles {
     class ACE_Module;
     class GVAR(module): ACE_Module {
-        author = "$STR_ACE_common_ACETeam";
         author = ACECSTRING(common,ACETeam);
         category = "ACEX";
         displayName = CSTRING(Module);

--- a/addons/headless/XEH_PREP.hpp
+++ b/addons/headless/XEH_PREP.hpp
@@ -1,3 +1,4 @@
+PREP(endMissionNoPlayers);
 PREP(handleConnectHC);
 PREP(handleDisconnect);
 PREP(handleInitPost);

--- a/addons/headless/XEH_preInit.sqf
+++ b/addons/headless/XEH_preInit.sqf
@@ -7,6 +7,7 @@ ADDON = false;
 if (isServer) then {
     GVAR(headlessClients) = [];
     GVAR(inRebalance) = false;
+    GVAR(endMissionCheckDelayed) = false;
     [QGVAR(headlessClientJoined), FUNC(handleConnectHC)] call CBA_fnc_addEventHandler;
 };
 

--- a/addons/headless/functions/fnc_endMissionNoPlayers.sqf
+++ b/addons/headless/functions/fnc_endMissionNoPlayers.sqf
@@ -16,12 +16,13 @@
 #include "script_component.hpp"
 
 // Exit if players connected
-if (call CBA_fnc_players > 0) exitWith {
+if !(call CBA_fnc_players isEqualTo []) exitWith {
     GVAR(endMissionCheckDelayed) = false;
+    TRACE_1("Players are present",count (call CBA_fnc_players));
 };
 
 // End mission
 [] call BIS_fnc_endMissionServer;
 if (GVAR(Log)) then {
-    ACE_LOGINFO("Ended Mission on all players leaving");
+    ACE_LOGINFO("Ended Mission on all players leaving.");
 };

--- a/addons/headless/functions/fnc_endMissionNoPlayers.sqf
+++ b/addons/headless/functions/fnc_endMissionNoPlayers.sqf
@@ -1,0 +1,27 @@
+/*
+ * Author: Jonpas
+ * Ends mission on server if no players are connected.
+ *
+ * Arguments:
+ * None
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [] call acex_headless_fnc_endMissionNoPlayers;
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+// Exit if players connected
+if (call CBA_fnc_players > 0) exitWith {
+    GVAR(endMissionCheckDelayed) = false;
+};
+
+// End mission
+[] call BIS_fnc_endMissionServer;
+if (GVAR(Log)) then {
+    ACE_LOGINFO("Ended Mission on all players leaving");
+};

--- a/addons/headless/functions/fnc_handleDisconnect.sqf
+++ b/addons/headless/functions/fnc_handleDisconnect.sqf
@@ -22,11 +22,11 @@ if !(_object in GVAR(headlessClients)) exitWith {
     // End mission when no players present
     if (GVAR(EndMission) && {!GVAR(endMissionCheckDelayed)}) then {
         // Delay check until 2.5 minutes into the mission - wait for allPlayers to sync
-        if (CBA_missionTime < 150000) then {
+        if (CBA_missionTime < 150) then {
             GVAR(endMissionCheckDelayed) = true;
             [{
                 call FUNC(endMissionNoPlayers);
-            }, [], (150000 - CBA_missionTime) / 100] call CBA_fnc_waitAndExecute;
+            }, [], 150 - CBA_missionTime] call CBA_fnc_waitAndExecute;
         } else {
             call FUNC(endMissionNoPlayers);
         };

--- a/addons/headless/functions/fnc_handleDisconnect.sqf
+++ b/addons/headless/functions/fnc_handleDisconnect.sqf
@@ -18,7 +18,16 @@
 params ["_object"];
 
 // Exit if not HC
-if !(_object in GVAR(headlessClients)) exitWith {};
+if !(_object in GVAR(headlessClients)) exitWith {
+    // End mission when no players present
+    if (GVAR(EndMission) && {(count allPlayers - count GVAR(headlessClients)) == 0}) then {
+        [] call BIS_fnc_endMissionServer;
+        if (GVAR(Log)) then {
+            ACE_LOGINFO("Ended Mission on all players leaving");
+        };
+    };
+    false
+};
 
 // Remove HC
 GVAR(headlessClients) deleteAt (GVAR(headlessClients) find _object);

--- a/addons/headless/functions/fnc_handleDisconnect.sqf
+++ b/addons/headless/functions/fnc_handleDisconnect.sqf
@@ -16,19 +16,30 @@
 #include "script_component.hpp"
 
 params ["_object"];
+TRACE_1("HandleDisconnect",_this);
 
 // Exit if not HC
 if !(_object in GVAR(headlessClients)) exitWith {
+    TRACE_2("Object not in HC list",_object,GVAR(headlessClients));
     // End mission when no players present
-    if (GVAR(EndMission) && {!GVAR(endMissionCheckDelayed)}) then {
+    if (GVAR(EndMission) != 0 && {!GVAR(endMissionCheckDelayed)}) then {
         // Delay check until 2.5 minutes into the mission - wait for allPlayers to sync
         if (CBA_missionTime < 150) then {
+            TRACE_1("Mission start delay",CBA_missionTime);
             GVAR(endMissionCheckDelayed) = true;
             [{
                 call FUNC(endMissionNoPlayers);
             }, [], 150 - CBA_missionTime] call CBA_fnc_waitAndExecute;
         } else {
-            call FUNC(endMissionNoPlayers);
+            // End instantly or after delay
+            if (GVAR(EndMission) == 1) then {
+                TRACE_2("Instant end",GVAR(endMission),CBA_missionTime);
+                call FUNC(endMissionNoPlayers);
+            } else {
+                TRACE_2("Delayed 60s end",GVAR(endMission),CBA_missionTime);
+                GVAR(endMissionCheckDelayed) = true;
+                [FUNC(endMissionNoPlayers), [], 60] call CBA_fnc_waitAndExecute;
+            };
         };
     };
     false

--- a/addons/headless/functions/fnc_handleDisconnect.sqf
+++ b/addons/headless/functions/fnc_handleDisconnect.sqf
@@ -20,11 +20,26 @@ params ["_object"];
 // Exit if not HC
 if !(_object in GVAR(headlessClients)) exitWith {
     // End mission when no players present
-    if (GVAR(EndMission) && {(count allPlayers - count GVAR(headlessClients)) == 0}) then {
-        [] call BIS_fnc_endMissionServer;
-        if (GVAR(Log)) then {
-            ACE_LOGINFO("Ended Mission on all players leaving");
+    if (GVAR(EndMission) && {!GVAR(endMissionCheckDelayed)}) then {
+        // Delay check until 2.5 minutes into the mission - wait for allPlayers to sync
+        private _delay = 0;
+        if (CBA_missionTime < 150000) then {
+            _delay = (150000 - CBA_missionTime) / 100;
         };
+
+        GVAR(endMissionCheckDelayed) = true;
+        [{
+            // Double check after allPlayers sync has completed
+            if (call CBA_fnc_players > 0) exitWith {
+                GVAR(endMissionCheckDelayed) = false;
+            };
+
+            // End mission
+            [] call BIS_fnc_endMissionServer;
+            if (GVAR(Log)) then {
+                ACE_LOGINFO("Ended Mission on all players leaving");
+            };
+        }, [], _delay] call CBA_fnc_waitAndExecute;
     };
     false
 };

--- a/addons/headless/functions/fnc_handleDisconnect.sqf
+++ b/addons/headless/functions/fnc_handleDisconnect.sqf
@@ -22,24 +22,14 @@ if !(_object in GVAR(headlessClients)) exitWith {
     // End mission when no players present
     if (GVAR(EndMission) && {!GVAR(endMissionCheckDelayed)}) then {
         // Delay check until 2.5 minutes into the mission - wait for allPlayers to sync
-        private _delay = 0;
         if (CBA_missionTime < 150000) then {
-            _delay = (150000 - CBA_missionTime) / 100;
+            GVAR(endMissionCheckDelayed) = true;
+            [{
+                call FUNC(endMissionNoPlayers);
+            }, [], (150000 - CBA_missionTime) / 100] call CBA_fnc_waitAndExecute;
+        } else {
+            call FUNC(endMissionNoPlayers);
         };
-
-        GVAR(endMissionCheckDelayed) = true;
-        [{
-            // Double check after allPlayers sync has completed
-            if (call CBA_fnc_players > 0) exitWith {
-                GVAR(endMissionCheckDelayed) = false;
-            };
-
-            // End mission
-            [] call BIS_fnc_endMissionServer;
-            if (GVAR(Log)) then {
-                ACE_LOGINFO("Ended Mission on all players leaving");
-            };
-        }, [], _delay] call CBA_fnc_waitAndExecute;
     };
     false
 };

--- a/addons/headless/functions/fnc_handleInitPost.sqf
+++ b/addons/headless/functions/fnc_handleInitPost.sqf
@@ -16,7 +16,6 @@
 #include "script_component.hpp"
 
 params ["_object"];
-
 TRACE_1("InitPost",_object);
 
 // Delay until settings are initialized (for checking if HC trasnferring is enabled)

--- a/addons/headless/functions/fnc_moduleInit.sqf
+++ b/addons/headless/functions/fnc_moduleInit.sqf
@@ -20,9 +20,9 @@ params ["_logic", "", "_activated"];
 
 if (!_activated) exitWith {};
 
-[_logic, QGVAR(Enabled), "Enabled"] call ACEFUNC(common,readSettingFromModule);
-[_logic, QGVAR(Delay), "Delay"] call ACEFUNC(common,readSettingFromModule);
-[_logic, QGVAR(EndMission), "EndMission"] call ACEFUNC(common,readSettingFromModule);
-[_logic, QGVAR(Log), "Log"] call ACEFUNC(common,readSettingFromModule);
+[_logic, QGVAR(enabled), "enabled"] call ACEFUNC(common,readSettingFromModule);
+[_logic, QGVAR(delay), "delay"] call ACEFUNC(common,readSettingFromModule);
+[_logic, QGVAR(endMission), "endMission"] call ACEFUNC(common,readSettingFromModule);
+[_logic, QGVAR(log), "log"] call ACEFUNC(common,readSettingFromModule);
 
 ACE_LOGINFO("Headless Module Initialized.");

--- a/addons/headless/functions/fnc_moduleInit.sqf
+++ b/addons/headless/functions/fnc_moduleInit.sqf
@@ -22,6 +22,7 @@ if (!_activated) exitWith {};
 
 [_logic, QGVAR(Enabled), "Enabled"] call ACEFUNC(common,readSettingFromModule);
 [_logic, QGVAR(Delay), "Delay"] call ACEFUNC(common,readSettingFromModule);
+[_logic, QGVAR(EndMission), "EndMission"] call ACEFUNC(common,readSettingFromModule);
 [_logic, QGVAR(Log), "Log"] call ACEFUNC(common,readSettingFromModule);
 
 ACE_LOGINFO("Headless Module Initialized.");

--- a/addons/headless/stringtable.xml
+++ b/addons/headless/stringtable.xml
@@ -26,6 +26,12 @@
             <German>Minimale Verzögerung zwischen Transfers in Sekunden. (Standard: 15)</German>
             <Polish>Minimalny odstęp pomiędzy transferami w sekundach. (Domyślnie: 15)</Polish>
         </Key>
+        <Key ID="STR_ACEX_Headless_EndMission">
+            <English>End Mission</English>
+        </Key>
+        <Key ID="STR_ACEX_Headless_EndMissionDesc">
+            <English>End mission when there are no players connected (same as 'persistent = 0' in server configuration but with Headless Client support)</English>
+        </Key>
         <Key ID="STR_ACEX_Headless_Log">
             <English>Log</English>
             <German>Protokolldatei anlegen</German>

--- a/addons/headless/stringtable.xml
+++ b/addons/headless/stringtable.xml
@@ -30,7 +30,13 @@
             <English>End Mission</English>
         </Key>
         <Key ID="STR_ACEX_Headless_EndMissionDesc">
-            <English>End mission when there are no players connected (same as 'persistent = 0' in server configuration but with Headless Client support)</English>
+            <English>End mission when there are no players connected (same as 'persistent = 0' in server configuration but with Headless Client support).</English>
+        </Key>
+        <Key ID="STR_ACEX_Headless_Instant">
+            <English>Instant</English>
+        </Key>
+        <Key ID="STR_ACEX_Headless_Delayed">
+            <English>Delayed (60s)</English>
         </Key>
         <Key ID="STR_ACEX_Headless_Log">
             <English>Log</English>


### PR DESCRIPTION
**When merged this pull request will:**
- Close #24 
- Adds a setting to Headless module to end mission when no players are present anymore, this mimics `persistent = 0;` in server config, however that server config entry does not make the mission end if headless clients are present.