### PR TITLE
Fix gunner and group view being disallowed when using View Restriction

### DIFF
--- a/addons/viewrestriction/XEH_clientInit.sqf
+++ b/addons/viewrestriction/XEH_clientInit.sqf
@@ -24,14 +24,14 @@ if !(hasInterface) exitWith {};
     };
 
     // Add Event Handler for changing camera - also happens on spawn
-    ["ace_cameraViewChanged", {
-        call FUNC(changeCamera);
-    }] call CBA_fnc_addEventHandler;
+    ["cameraView", {
+        [_this select 1, cameraOn] call FUNC(changeCamera);
+    }] call CBA_fnc_addPlayerEventHandler;
 
-    // Add Event Hander for exiting and entering a vehicle when on Selective mode
+    // Add Event Hander for exiting and entering a vehicle when on Selective mode - cameraView does not fire on simple enter/exit
     if (GVAR(mode) == 3) then {
-        ["ace_playerVehicleChanged", {
-            call FUNC(changeCamera);
-        }] call CBA_fnc_addEventHandler;
+        ["vehicle", {
+            [cameraView, _this select 1] call FUNC(changeCamera);
+        }] call CBA_fnc_addPlayerEventHandler;
     };
 }] call CBA_fnc_addEventHandler;

--- a/addons/viewrestriction/functions/fnc_canChangeCamera.sqf
+++ b/addons/viewrestriction/functions/fnc_canChangeCamera.sqf
@@ -3,23 +3,27 @@
  * Checks if camera can be changed.
  *
  * Arguments:
- * None
+ * 0: New Camera View <STRING>
+ * 1: Vehicle <OBJECT>
  *
  * Return Value:
  * Can Change Camera <BOOL>
  *
  * Example:
- * [] call acex_viewrestriction_fnc_canChangeCamera
+ * ["INTERNAL", vehicle] call acex_viewrestriction_fnc_canChangeCamera
  *
  * Public: No
  */
 #include "script_component.hpp"
 
+params ["_newCameraView", "_cameraOn"];
+
 // Remote control hates switchCamera (control returns to player, camera is left on remotely controlled object/unit), make sure remote controlled units are not impacted
 
-!isNull ACE_player &&
-(player == ACE_player) &&
+!(_newCameraView in ["GUNNER", "GROUP"]) &&
+{!isNull ACE_player} &&
+{player == ACE_player} &&
 {alive ACE_player} &&
-{ACE_player == cameraOn || vehicle ACE_player == cameraOn} &&
+{ACE_player == _cameraOn || vehicle ACE_player == _cameraOn} &&
 {!call ACEFUNC(common,isFeatureCameraActive)} &&
-{!(cameraOn isKindOf "UAV" || cameraOn isKindOf "UAV_01_base_F")} // UAVs are remote controlled
+{!(_cameraOn isKindOf "UAV" || _cameraOn isKindOf "UAV_01_base_F")} // UAVs are remote controlled

--- a/addons/viewrestriction/functions/fnc_changeCamera.sqf
+++ b/addons/viewrestriction/functions/fnc_changeCamera.sqf
@@ -3,33 +3,36 @@
  * Change camera based on setting.
  *
  * Arguments:
- * None
+ * 0: New Camera View <STRING>
+ * 1: Vehicle <OBJECT>
  *
  * Return Value:
  * None
  *
  * Example:
- * [] call acex_viewrestriction_fnc_changeCamera
+ * ["INTERNAL", vehicle] call acex_viewrestriction_fnc_changeCamera
  *
  * Public: No
  */
 #include "script_component.hpp"
 
-if (!call FUNC(canChangeCamera)) exitWith {};
+params ["_newCameraView", "_cameraOn"];
+
+if (! ([_newCameraView, _cameraOn] call FUNC(canChangeCamera))) exitWith {};
 
 TRACE_1("View Restricted",GVAR(mode));
 
 // FirstPerson
 if (GVAR(mode) == 1) exitWith {
-    cameraOn switchCamera "Internal";
+    _cameraOn switchCamera "INTERNAL";
 };
 
 // ThirdPerson
 if (GVAR(mode) == 2) exitWith {
-    cameraOn switchCamera "External";
+    _cameraOn switchCamera "EXTERNAL";
 };
 
 // Selective
 if (GVAR(mode) == 3) exitWith {
-    call FUNC(selectiveChangeCamera);
+    [_cameraOn] call FUNC(selectiveChangeCamera);
 };

--- a/addons/viewrestriction/functions/fnc_selectiveChangeCamera.sqf
+++ b/addons/viewrestriction/functions/fnc_selectiveChangeCamera.sqf
@@ -3,65 +3,67 @@
  * Changes camera mode based on vehicle type the player is currently occupying.
  *
  * Arguments:
- * None
+ * 0: Vehicle <OBJECT>
  *
  * Return Value:
  * None
  *
  * Example:
- * [] call acex_viewrestriction_fnc_selectiveChangeCamera
+ * [vehicle] call acex_viewrestriction_fnc_selectiveChangeCamera
  *
  * Public: No
  */
 #include "script_component.hpp"
 
+params ["_cameraOn"];
+
 // Foot
-if (cameraOn isKindOf "CAManBase") exitWith {
+if (_cameraOn isKindOf "CAManBase") exitWith {
     if (GVAR(modeSelectiveFoot) == 1) exitWith {
-        cameraOn switchCamera "Internal";
+        _cameraOn switchCamera "INTERNAL";
     };
     if (GVAR(modeSelectiveFoot) == 2) exitWith {
-        cameraOn switchCamera "External";
+        _cameraOn switchCamera "EXTERNAL";
     };
 };
 
 // Land Vehicles
-if (cameraOn isKindOf "LandVehicle") exitWith {
+if (_cameraOn isKindOf "LandVehicle") exitWith {
     if (GVAR(modeSelectiveLand) == 1) exitWith {
-        cameraOn switchCamera "Internal";
+        _cameraOn switchCamera "INTERNAL";
     };
     if (GVAR(modeSelectiveLand) == 2) exitWith {
-        cameraOn switchCamera "External";
+        _cameraOn switchCamera "EXTERNAL";
     };
 };
 
 // UAVs (must be evaluated before Air Vehicles due to inheritance tree)
 // Disabled - Reference comment in FUNC(canChangeCamera)
-/*if (cameraOn isKindOf "UAV" || {cameraOn isKindOf "UAV_01_base_F"}) exitWith {
+/*if (_cameraOn isKindOf "UAV" || {_cameraOn isKindOf "UAV_01_base_F"}) exitWith {
     if (GVAR(modeSelectiveUAV) == 1) exitWith {
-        cameraOn switchCamera "Internal";
+        _cameraOn switchCamera "INTERNAL";
     };
     if (GVAR(modeSelectiveUAV) == 2) exitWith {
-        cameraOn switchCamera "External";
+        _cameraOn switchCamera "EXTERNAL";
     };
 };*/
 
 // Air Vehicles (must be evaluated after UAVs due to inheritance tree)
-if (cameraOn isKindOf "Air") exitWith {
+if (_cameraOn isKindOf "Air") exitWith {
     if (GVAR(modeSelectiveAir) == 1) exitWith {
-        cameraOn switchCamera "Internal";
+        _cameraOn switchCamera "INTERNAL";
     };
     if (GVAR(modeSelectiveAir) == 2) exitWith {
-        cameraOn switchCamera "External";
+        _cameraOn switchCamera "EXTERNAL";
     };
 };
 
 // Sea Vehicles
-if (cameraOn isKindOf "Ship") exitWith {
+if (_cameraOn isKindOf "Ship") exitWith {
     if (GVAR(modeSelectiveSea) == 1) exitWith {
-        cameraOn switchCamera "Internal";
+        _cameraOn switchCamera "INTERNAL";
     };
     if (GVAR(modeSelectiveSea) == 2) exitWith {
-        cameraOn switchCamera "External";
+        _cameraOn switchCamera "EXTERNAL";
     };
 };


### PR DESCRIPTION
**When merged this pull request will:**
- Title - fix #27 
- Replace player events with CBA player events
- Improve performance with parameters
- Capitalize camera views to be same as `cameraView` returns