### PR TITLE
Add kill/death tracker to acex

### DIFF
--- a/addons/killtracker/$PBOPREFIX$
+++ b/addons/killtracker/$PBOPREFIX$
@@ -1,0 +1,1 @@
+z\acex\addons\killtracker

--- a/addons/killtracker/CfgEventHandlers.hpp
+++ b/addons/killtracker/CfgEventHandlers.hpp
@@ -1,0 +1,5 @@
+class Extended_PostInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_postInit));
+    };
+};

--- a/addons/killtracker/README.md
+++ b/addons/killtracker/README.md
@@ -1,0 +1,21 @@
+acex_killTracker
+============
+
+Tracks deaths/kills and logs to the end mission disaplay. Attemps to log kills from ace_medical by using ace_medical_lastDamageSource.
+
+Note: Requires config setup in a mission's description.ext - has no effect if mission is not setup correctly.
+
+```powershell
+    class CfgDebriefingSections {
+        class acex_killTracker {
+            title = "Acex Killed Events";
+            variable = "acex_killTracker_outputText";
+        };
+    };
+```
+
+## Maintainers
+
+The people responsible for merging changes to this component or answering potential questions.
+
+- [PabstMirror](https://github.com/PabstMirror)

--- a/addons/killtracker/XEH_postInit.sqf
+++ b/addons/killtracker/XEH_postInit.sqf
@@ -1,0 +1,129 @@
+/*
+ * Author: PabstMirror
+ * Tracks deaths/kills and logs to the end mission disaplay
+ * Attemps to log kills from ace_medical by using ace_medical_lastDamageSource
+ *
+ * Note: Requires config setup in a mission's description.ext
+ * Has no effect if mission is not setup correctly
+ *
+ * Arguments:
+ * Nothing
+ *
+ * Return Value:
+ * Nothing
+ *
+ * Public: No
+ */
+#define DEBUG_MODE_FULL
+#include "script_component.hpp"
+
+// place the following in a misison's description.ext:
+/*
+    class CfgDebriefingSections {
+        class acex_killTracker {
+            title = "Acex Killed Events";
+            variable = "acex_killTracker_outputText";
+        };
+    };
+ */
+if ((getText (missionconfigfile >> "CfgDebriefingSections" >> QUOTE(ADDON) >> "variable")) != QGVAR(outputText)) exitWith {
+    TRACE_1("no mission debriefing config",_this);
+};
+
+ACE_LOGINFO("Running Kill Tracking");
+
+// Variables:
+GVAR(eventsArray) = [];
+GVAR(outputText) = "None";
+
+// Add Event Handlers:
+[QGVAR(kill), {
+    params ["_name", "_killInfo"];
+    TRACE_2("kill eh",_name,_killInfo);
+    GVAR(eventsArray) pushBack format ["Killed: %1 %2", _name, _killInfo];
+    GVAR(outputText) = (GVAR(eventsArray) joinString "<br/>");
+}] call CBA_fnc_addEventHandler;
+
+[QGVAR(death), {
+    params ["_name", "_killInfo"];
+    TRACE_2("death eh",_name,_killInfo);
+    GVAR(eventsArray) pushBack format ["Died: %1 %2", _name, _killInfo];
+    GVAR(outputText) = (GVAR(eventsArray) joinString "<br/>");
+}] call CBA_fnc_addEventHandler;
+
+// Add Killed Event Handler - killed EH and lastDamageSource var are local only
+["CAManBase", "killed", {
+    params ["_unit", ["_killer", objNull]];
+    TRACE_2("killed",_unit,_killer);
+
+    private _killInfo = [];
+    if ((isNull _killer) || {_killer == _unit}) then {
+        private _aceSource = _unit getVariable ["ace_medical_lastDamageSource", objNull];
+        TRACE_1("",_aceSource);
+        if ((!isNull _aceSource) && {_aceSource != _unit}) then {
+            _killInfo pushBack "Last damage";
+            _killer = _aceSource;
+        };
+    };
+
+    // If killer is a vehicle get the commander (this is how vanilla does it?) and log the vehicle type
+    if ((!isNull _killer) && {!(_killer isKindof "CAManBase")}) then {
+        _killInfo pushBack format ["Vehicle: %1", getText (configfile >> "CfgVehicles" >> (typeOf _killer) >> "displayName")];
+        _killer = effectiveCommander _killer;
+    };
+
+    private _unitIsPlayer = hasInterface && {_unit == ace_player}; // isPlayer check will fail at this point
+    private _killerIsPlayer = (!isNull _killer) && {_unit != _killer} && {[_killer] call ACEFUNC(common,isPlayer)};
+    TRACE_2("",_unitIsPlayer,_killerIsPlayer);
+
+    // Don't do anything if neither are players
+    if (!(_unitIsPlayer || _killerIsPlayer)) exitWith {};
+
+    // Log firendly fire
+    if ((!isNull _killer) && {_unit != _killer}) then {
+        // side group is better, but group could already be null if it was last unit
+        private _unitSide = if (!isNull (group _unit)) then {side group _unit} else {side _unit};
+        private _killerSide = if (!isNull (group _killer)) then {side group _killer} else {side _killer};
+        if ([_unitSide, _killerSide] call BIS_fnc_areFriendly) then {
+            _killInfo pushBack "<t color='#ff0000'>Friendly Fire</t>";
+        };
+    };
+
+    // Log bleed out - ToDo: could change setDead to log the specific medical cause (e.g. blood loss / cardiac arrest / overdose)
+    private _bloodVolume = _unit getVariable ["ace_medical_bloodVolume", 100];
+    if (_bloodVolume <= 60) then {
+        _killInfo pushBack format ["Blood %1%2", floor _bloodVolume, "%"];
+    };
+
+    // Parse info into text
+    _killInfo = if (_killInfo isEqualTo []) then {
+        ""
+    } else {
+        format [" - [%1]", (_killInfo joinString ", ")];
+    };
+
+    // If unit was player then send event to self
+    if (_unitIsPlayer) then {
+        private _killerName = "Self?";
+        if ((!isNull _killer) && {_unit != _killer}) then {
+            if (_killerIsPlayer) then {
+                _killerName = [_killer, true, false] call ACEFUNC(common,getName);
+            } else {
+                _killerName = format ["*AI* - %1", getText (configfile >> "CfgVehicles" >> (typeOf _killer) >> "displayName")];
+            };
+        };
+        TRACE_3("send death event",_unit,_killerName,_killInfo);
+        [QGVAR(death), [_killerName, _killInfo]] call CBA_fnc_localEvent;
+    };
+
+    // If killer was player then send event to killer
+    if (_killerIsPlayer) then {
+        private _unitName = if (_unitIsPlayer) then {
+            [_unit, true, false] call ACEFUNC(common,getName); // should be same as profileName
+        } else {
+            format ["*AI* - %1", getText (configfile >> "CfgVehicles" >> (typeOf _unit) >> "displayName")];
+        };
+        TRACE_3("send kill event",_killer,_unitName,_killInfo);
+        [QGVAR(kill), [_unitName, _killInfo], _killer] call CBA_fnc_targetEvent;
+    };
+}] call CBA_fnc_addClassEventHandler;

--- a/addons/killtracker/config.cpp
+++ b/addons/killtracker/config.cpp
@@ -1,0 +1,17 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = COMPONENT_NAME;
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"acex_main", "ace_medical"};
+        author = ACECSTRING(common,ACETeam);
+        authors[]= {"PabstMirror"};
+        url = ACECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgEventHandlers.hpp"

--- a/addons/killtracker/script_component.hpp
+++ b/addons/killtracker/script_component.hpp
@@ -1,0 +1,18 @@
+#define COMPONENT killtracker
+#define COMPONENT_BEAUTIFIED KillTracker
+#include "\z\acex\addons\main\script_mod.hpp"
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define CBA_DEBUG_SYNCHRONOUS
+// #define ENABLE_PERFORMANCE_COUNTERS
+
+#ifdef DEBUG_ENABLED_KILLTRACKER
+    #define DEBUG_MODE_FULL
+#endif
+
+#ifdef DEBUG_SETTINGS_KILLTRACKER
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_KILLTRACKER
+#endif
+
+#include "\z\acex\addons\main\script_macros.hpp"

--- a/addons/killtracker/stringtable.xml
+++ b/addons/killtracker/stringtable.xml
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project name="ACEX">
+    <Package name="KillTracker">
+    </Package>
+</Project>


### PR DESCRIPTION
Redo https://github.com/acemod/ACE3/pull/4229 as an addon for acex

Will show kills at mission end screen.
Attempts to ID killer when unit's death was scripted.

Example below, note the vanilla kill system only shows 2 kills where as this system shows 5.
![x](https://cloud.githubusercontent.com/assets/9376747/17581386/11222edc-5f6b-11e6-8c76-5208457bc877.jpg)

The last damage source isn't going to be perfect; e.g. get shot once, and then fall out of a chopper 30 minutes later.
