### PR TITLE
Fix erroneous firendly fire msg if side is weird

### DIFF
--- a/addons/killtracker/XEH_postInit.sqf
+++ b/addons/killtracker/XEH_postInit.sqf
@@ -80,10 +80,19 @@ GVAR(outputText) = "None";
     if (!(_unitIsPlayer || _killerIsPlayer)) exitWith {};
 
     // Log firendly fire
-    if ((!isNull _killer) && {_unit != _killer}) then {
-        // side group is better, but group could already be null if it was last unit
-        private _unitSide = if (!isNull (group _unit)) then {side group _unit} else {side _unit};
-        private _killerSide = if (!isNull (group _killer)) then {side group _killer} else {side _killer};
+    private _fnc_getSideFromConfig = {
+        params ["_object"];
+        switch (getNumber (configFile >> "CfgVehicles" >> (typeOf _object) >> "side")) do {
+            case (0): {east};
+            case (1): {west};
+            case (2): {resistance};
+            default {civilian};
+        };
+    };
+    if ((!isNull _killer) && {_unit != _killer} && {_killer isKindOf "CAManBase"}) then {
+        // Because of unconscious group switching/captives it's probably best to just use unit's config side
+        private _unitSide = [_unit] call _fnc_getSideFromConfig;
+        private _killerSide = [_killer] call _fnc_getSideFromConfig;
         if ([_unitSide, _killerSide] call BIS_fnc_areFriendly) then {
             _killInfo pushBack "<t color='#ff0000'>Friendly Fire</t>";
         };

--- a/addons/killtracker/XEH_postInit.sqf
+++ b/addons/killtracker/XEH_postInit.sqf
@@ -14,7 +14,7 @@
  *
  * Public: No
  */
-#define DEBUG_MODE_FULL
+// #define DEBUG_MODE_FULL
 #include "script_component.hpp"
 
 // place the following in a misison's description.ext:


### PR DESCRIPTION
We've been using this for about a month, kept getting reports of friendly fire that shouldn't.
I think the cause could be group switching on medical.
Easiest solution is to just use the `side` in the unit's config.

