### PR TITLE
Allow headless blacklist on group, Fix empty group check

### DIFF
--- a/addons/headless/functions/fnc_transferGroups.sqf
+++ b/addons/headless/functions/fnc_transferGroups.sqf
@@ -65,7 +65,7 @@ private _numTransferredHC3 = 0;
 // Transfer AI groups
 {
     // No transfer if empty group
-    private _transfer = !(_x isEqualTo []) && {!(_x getVariable [QGVAR(blacklist), false])};
+    private _transfer = !(units _x isEqualTo []) && {!(_x getVariable [QGVAR(blacklist), false])};
     if (_transfer) then {
         {
             // No transfer if already transferred

--- a/addons/headless/functions/fnc_transferGroups.sqf
+++ b/addons/headless/functions/fnc_transferGroups.sqf
@@ -65,7 +65,7 @@ private _numTransferredHC3 = 0;
 // Transfer AI groups
 {
     // No transfer if empty group
-    private _transfer = !(_x isEqualTo []);
+    private _transfer = !(_x isEqualTo []) && {!(_x getVariable [QGVAR(blacklist), false])};
     if (_transfer) then {
         {
             // No transfer if already transferred


### PR DESCRIPTION
**When merged this pull request will:**
- Allow mission makers to blacklist a group, previously only units were checked