### PR TITLE
Prevent sitting on another chair if already sitting

### DIFF
--- a/addons/sitting/functions/fnc_canSit.sqf
+++ b/addons/sitting/functions/fnc_canSit.sqf
@@ -4,20 +4,22 @@
  *
  * Arguments:
  * 0: Seat <OBJECT>
+ * 1: Player <OBJECT>
  *
  * Return Value:
  * Can Sit Down <BOOL>
  *
  * Example:
- * [seat] call acex_sitting_fnc_canSit
+ * [seat, player] call acex_sitting_fnc_canSit
  *
  * Public: No
  */
 #include "script_component.hpp"
 
-params ["_seat"];
+params ["_seat", "_player"];
 
 // Sitting enabled, is seat object, not occupied and standing up (or not on a big slope)
 GVAR(enable) &&
+{isNil {_player getVariable QGVAR(isSitting)}} &&
 {!(_seat call ACEFUNC(common,owned))} &&
 {round (vectorUp _seat select 0) == 0 && {round (vectorUp _seat select 1) == 0} && {round (vectorUp _seat select 2) == 1}}


### PR DESCRIPTION
**When merged this pull request will:**
- Title

Player could chain sitting from one chair to the other, taking ownership of all of them so no one else including that player could sit on it again.