### PR TITLE
Optimize Sitting initialization

### DIFF
--- a/addons/sitting/CfgEventHandlers.hpp
+++ b/addons/sitting/CfgEventHandlers.hpp
@@ -24,12 +24,3 @@ class Extended_Killed_EventHandlers {
         };
     };
 };
-
-// Need initPost or there are problems with setVariable
-class Extended_InitPost_EventHandlers {
-    class ThingX {
-        class ADDON {
-            init = QUOTE(_this call DFUNC(addSitActions));
-        };
-    };
-};

--- a/addons/sitting/XEH_clientInit.sqf
+++ b/addons/sitting/XEH_clientInit.sqf
@@ -3,7 +3,7 @@
 // Exit on Headless
 if (!hasInterface) exitWith {};
 
-["ThingX", "init", {call FUNC(addSitActions)}, nil, nil, true] call CBA_fnc_addClassEventHandler;
+["ThingX", "init", FUNC(addSitActions), nil, nil, true] call CBA_fnc_addClassEventHandler;
 
 GVAR(isEnabled) = false;
 DFUNC(onInitEvent) = {

--- a/addons/sitting/XEH_clientInit.sqf
+++ b/addons/sitting/XEH_clientInit.sqf
@@ -3,6 +3,8 @@
 // Exit on Headless
 if (!hasInterface) exitWith {};
 
+["ThingX", "init", {call FUNC(addSitActions)}, nil, nil, true] call CBA_fnc_addClassEventHandler;
+
 GVAR(isEnabled) = false;
 DFUNC(onInitEvent) = {
     TRACE_1("SettingInit", GVAR(enable));

--- a/addons/sitting/XEH_clientInit.sqf
+++ b/addons/sitting/XEH_clientInit.sqf
@@ -3,15 +3,16 @@
 // Exit on Headless
 if (!hasInterface) exitWith {};
 
-["ThingX", "init", FUNC(addSitActions), nil, nil, true] call CBA_fnc_addClassEventHandler;
-
 GVAR(isEnabled) = false;
-DFUNC(onInitEvent) = {
+["ace_settingsInitialized", {
     TRACE_1("SettingInit", GVAR(enable));
 
-    //If not enabled, then do not add CanInteractWith Condition or event handlers:
+    // If not enabled, then do not add CanInteractWith Condition or event handlers
     if (!GVAR(enable) || GVAR(isEnabled)) exitWith {};
     GVAR(isEnabled) = true;
+
+    // Initialize classes as they spawn
+    ["ThingX", "init", FUNC(addSitActions), nil, nil, true] call CBA_fnc_addClassEventHandler;
 
     // Add interaction menu exception
     ["isNotSitting", {isNil {(_this select 0) getVariable QGVAR(isSitting)}}] call ACEFUNC(common,addCanInteractWithCondition);
@@ -19,13 +20,4 @@ DFUNC(onInitEvent) = {
     // Handle interruptions
     ["ace_unconscious", {_this call DFUNC(handleInterrupt)}] call CBA_fnc_addEventHandler;
     ["ace_captives_SetHandcuffed", {_this call DFUNC(handleInterrupt)}] call CBA_fnc_addEventHandler;
-};
-
-["ace_settingsInitialized", {
-    call FUNC(onInitEvent);
-}] call CBA_fnc_addEventHandler;
-
-["ace_settingChanged", {
-    params ["_name", "_value", "_force"];
-    call FUNC(onInitEvent);
 }] call CBA_fnc_addEventHandler;

--- a/addons/sitting/XEH_preInit.sqf
+++ b/addons/sitting/XEH_preInit.sqf
@@ -4,6 +4,8 @@ ADDON = false;
 
 #include "XEH_PREP.hpp"
 
-GVAR(initializedClasses) = [];
+if (hasInterface) then {
+    GVAR(initializedClasses) = [];
+};
 
 ADDON = true;


### PR DESCRIPTION
**When merged this pull request will:**
- Initialize sit actions only on clients with interface and if sitting is enabled
- Use CBA Class Event Handler for initialization, applied retroactively
- Remove `settingChanged` EH as it cannot be enabled mid-mission