### PR TITLE
Fix volume state after respawn

### DIFF
--- a/addons/volume/XEH_postInitClient.sqf
+++ b/addons/volume/XEH_postInitClient.sqf
@@ -32,3 +32,6 @@ if (!hasInterface) exitWith {};
 
 // Self-calling reminder
 [FUNC(remind), [], REMINDER_DELAY] call CBA_fnc_waitAndExecute;
+
+// Restore volume on respawn
+ace_player addEventHandler ["Respawn", FUNC(restoreVolume)];


### PR DESCRIPTION
**When merged this pull request will:**
- Fix this issue: https://github.com/acemod/ACEX/issues/77

Volume state isn't persisted, instead it's just restored. I don't think there's any need to over complicate it.