### PR TITLE
(sitting) stand up if player moved

### DIFF
--- a/addons/sitting/functions/fnc_sit.sqf
+++ b/addons/sitting/functions/fnc_sit.sqf
@@ -65,7 +65,7 @@ private _seatPosOrig = getPosASL _seat;
     };
 
     //  Stand up if chair gets deleted or moved
-    if (isNull _seat || !((getPosASL _seat) isEqualTo _seatPosOrig)) exitWith {
+    if (isNull _seat || {getPosASL _player distance _seatPosOrig > 1} || {!((getPosASL _seat) isEqualTo _seatPosOrig)}) exitWith {
         _player call FUNC(stand);
         TRACE_2("Chair moved",getPosASL _seat,_seatPosOrig);
     };


### PR DESCRIPTION
**When merged this pull request will:**
- Stand up if player is moved from seat position (e.g teleported)

The chairs I tested on the diff was < 0.2. 1m enough or too high?