### PR TITLE
CBA Settings Compat - Run readSettingFromModule on all machines

### DIFF
--- a/addons/headless/functions/fnc_moduleInit.sqf
+++ b/addons/headless/functions/fnc_moduleInit.sqf
@@ -14,8 +14,6 @@
  */
 #include "script_component.hpp"
 
-if (!isServer) exitWith {};
-
 params ["_logic", "", "_activated"];
 
 if (!_activated) exitWith {};

--- a/addons/sitting/functions/fnc_moduleInit.sqf
+++ b/addons/sitting/functions/fnc_moduleInit.sqf
@@ -14,8 +14,6 @@
  */
 #include "script_component.hpp"
 
-if (!isServer) exitWith {};
-
 params ["_logic", "_units", "_activated"];
 
 if (!_activated) exitWith {};

--- a/addons/viewrestriction/functions/fnc_moduleInit.sqf
+++ b/addons/viewrestriction/functions/fnc_moduleInit.sqf
@@ -12,8 +12,6 @@
  */
 #include "script_component.hpp"
 
-if (!isServer) exitWith {};
-
 params ["_logic", "_units", "_activated"];
 
 if (!_activated) exitWith {};


### PR DESCRIPTION
`ace_common_fnc_readSettingFromModule` now only has local effects, 
so modules must be read on all machines