### PR TITLE
Improve Headless type blacklist

### DIFF
--- a/addons/headless/XEH_preInit.sqf
+++ b/addons/headless/XEH_preInit.sqf
@@ -10,9 +10,8 @@ if (isServer) then {
     GVAR(headlessClients) = [];
     GVAR(inRebalance) = false;
     GVAR(endMissionCheckDelayed) = false;
+    GVAR(blacklistType) = [BLACKLIST_UAV];
     [QGVAR(headlessClientJoined), FUNC(handleConnectHC)] call CBA_fnc_addEventHandler;
 };
-
-GVAR(kindOfBlackList) = [];
 
 ADDON = true;

--- a/addons/headless/functions/fnc_handleSpawn.sqf
+++ b/addons/headless/functions/fnc_handleSpawn.sqf
@@ -19,7 +19,12 @@ params ["_object"];
 TRACE_1("Spawn",_object);
 
 // Exit if HC transferring disabled or object not a unit (including unit inside vehicle) or is player
-if (!(_object in allUnits) || {isPlayer _object} || {{_object isKindOf _x} count (HC_BLACKLIST + GVAR(kindOfBlackList)) > 0}) exitWith {};
+if (!(_object in allUnits) || {isPlayer _object}) exitWith {};
+
+// Exit and blacklist if of blacklist type
+if ({_object isKindOf _x} count GVAR(blacklistType) > 0) exitWith {
+    _object setVariable [QGVAR(blacklist), true];
+};
 
 // Rebalance
 [false] call FUNC(rebalance);

--- a/addons/headless/functions/fnc_transferGroups.sqf
+++ b/addons/headless/functions/fnc_transferGroups.sqf
@@ -93,12 +93,6 @@ private _numTransferredHC3 = 0;
             if (vehicle _x != _x && {(vehicle _x) getVariable [QGVAR(blacklist), false]}) exitWith {
                 _transfer = false;
             };
-            
-            // No transfer if hardcore blacklisted
-            private _unit = _x;
-            if ({_unit isKindOf _x} count (HC_BLACKLIST + GVAR(kindOfBlackList)) > 0) exitWith {
-                _transfer = false;
-            };
         } forEach (units _x);
     };
 

--- a/addons/headless/script_component.hpp
+++ b/addons/headless/script_component.hpp
@@ -17,4 +17,4 @@
 #include "\z\acex\addons\main\script_macros.hpp"
 
 #define DELAY_DEFAULT 15
-#define HC_BLACKLIST ["UAV", "UAV_AI_base_F", "B_UAV_AI", "O_UAV_AI", "I_UAV_AI"]
+#define BLACKLIST_UAV "UAV", "UAV_AI_base_F", "B_UAV_AI", "O_UAV_AI", "I_UAV_AI"


### PR DESCRIPTION
**When merged this pull request will:**
- Improve #86 
- Set global variable only on server where it is used
- Set blacklist variable on object if object is in blacklist (by type, `isKindOf`), removes need to manually check during transfer, but only once on spawn

I'd like to improve `blacklistType` into proper API (CBA Settings maybe?), but this can be merged for 3.3.0 if someone can test it.