### PR TITLE
View Restriction: Add setting to preserve view for vehicle types

### DIFF
--- a/addons/viewrestriction/XEH_PREP.hpp
+++ b/addons/viewrestriction/XEH_PREP.hpp
@@ -2,3 +2,4 @@ PREP(canChangeCamera);
 PREP(changeCamera);
 PREP(moduleInit);
 PREP(selectiveChangeCamera);
+PREP(switchPreserveView);

--- a/addons/viewrestriction/XEH_preInit.sqf
+++ b/addons/viewrestriction/XEH_preInit.sqf
@@ -6,4 +6,6 @@ PREP_RECOMPILE_START;
 #include "XEH_PREP.hpp"
 PREP_RECOMPILE_END;
 
+#include "initSettings.sqf"
+
 ADDON = true;

--- a/addons/viewrestriction/functions/fnc_switchPreserveView.sqf
+++ b/addons/viewrestriction/functions/fnc_switchPreserveView.sqf
@@ -1,0 +1,49 @@
+/*
+ * Author: Dystopian
+ * Controls View Preserving state.
+ *
+ * Arguments:
+ * 0: Enabled <BOOL>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * true call acex_viewrestriction_fnc_switchPreserveView
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+params ["_enabled"];
+if (!_enabled || {GVAR(mode) > 0}) exitWith {
+    if (isNil QGVAR(preserveViewCameraViewEH)) exitWith {};
+    ["cameraView", GVAR(preserveViewCameraViewEH)] call CBA_fnc_removePlayerEventHandler;
+    ["vehicle", GVAR(preserveViewVehicleEH)] call CBA_fnc_removePlayerEventHandler;
+    GVAR(preserveViewCameraViewEH) = nil;
+    GVAR(preserveViewVehicleEH) = nil;
+};
+
+GVAR(preserveViewCameraViewEH) = ["cameraView", {
+    params ["_player", "_cameraView"];
+    if !([_cameraView, cameraOn] call FUNC(canChangeCamera)) exitWith {};
+
+    private _vehicle = vehicle _player;
+    private _vehicleClass = {if (_vehicle isKindOf _x) exitWith {_x}} forEach ["CAManBase", "LandVehicle", "Air", "Ship", "All"];
+    private _varName = QGVAR(preserveView) + _vehicleClass;
+    if !(_cameraView isEqualTo (profileNamespace getVariable [_varName, ""])) then {
+        profileNamespace setVariable [_varName, _cameraView];
+    };
+}] call CBA_fnc_addPlayerEventHandler;
+
+GVAR(preserveViewVehicleEH) = ["vehicle", {
+    params ["_player", "_vehicle"];
+    private _cameraView = cameraView;
+    if !([_cameraView, cameraOn] call FUNC(canChangeCamera)) exitWith {};
+
+    private _vehicleClass = {if (_vehicle isKindOf _x) exitWith {_x}} forEach ["CAManBase", "LandVehicle", "Air", "Ship", "All"];
+    private _savedView = profileNamespace getVariable (QGVAR(preserveView) + _vehicleClass);
+    if (!isNil "_savedView" && {!(_cameraView isEqualTo _savedView)}) then {
+        _vehicle switchCamera _savedView;
+    };
+}, true] call CBA_fnc_addPlayerEventHandler;

--- a/addons/viewrestriction/initSettings.sqf
+++ b/addons/viewrestriction/initSettings.sqf
@@ -1,0 +1,9 @@
+[
+    QGVAR(preserveView),
+    "CHECKBOX",
+    [LSTRING(SettingPreserveViewName), LSTRING(SettingPreserveViewDesc)],
+    "ACEX " + localize LSTRING(ModuleDisplayName),
+    false,
+    false,
+    LINKFUNC(switchPreserveView)
+] call CBA_settings_fnc_init;

--- a/addons/viewrestriction/stringtable.xml
+++ b/addons/viewrestriction/stringtable.xml
@@ -210,5 +210,13 @@
             <Chinesesimp>使用可选设定</Chinesesimp>
             <Chinese>使用可選設定</Chinese>
         </Key>
+        <Key ID="STR_ACEX_ViewRestriction_SettingPreserveViewName">
+            <English>Preserve view for vehicle types</English>
+            <Russian>Запоминать вид для типов техники</Russian>
+        </Key>
+        <Key ID="STR_ACEX_ViewRestriction_SettingPreserveViewDesc">
+            <English>Switch view on vehicle change to last used in this vehicle type (Requires Mode: Disabled)</English>
+            <Russian>Переключать вид при смене техники на последний использованный в данном типе техники (требуется Режим: Отключен)</Russian>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- title.

This feature switches view on vehicle enter/exit to last used in this vehicle type/on foot. Supported types are the same as for `Selective` mode: `LandVehicle`, `Air`, `Ship`.
This setting will work only if View Restriction mode is `Disabled`.

Please higher attention to english strings.

To discuss:
- preserve view for vehicle type + seat type (driver, cargo, turret)?