### PR TITLE
(fortify) allow custom deploy handlers

### DIFF
--- a/addons/fortify/XEH_PREP.hpp
+++ b/addons/fortify/XEH_PREP.hpp
@@ -1,5 +1,6 @@
 TRACE_1("",QUOTE(ADDON));
 
+PREP(addDeployHandler);
 PREP(registerObjects);
 PREP(canFortify);
 PREP(deployObject);

--- a/addons/fortify/XEH_preInit.sqf
+++ b/addons/fortify/XEH_preInit.sqf
@@ -10,4 +10,8 @@ PREP_RECOMPILE_END;
 // Can add anything that would work in inArea (triggers, markers or array format [center, a, b, angle, isRectangle, c])
 GVAR(locations) = [];
 
+// Custom deploy handlers
+GVAR(deployHandlers) = [];
+
+
 ADDON = true;

--- a/addons/fortify/functions/fnc_addDeployHandler.sqf
+++ b/addons/fortify/functions/fnc_addDeployHandler.sqf
@@ -11,7 +11,7 @@
  * None
  *
  * Example:
- * [{alive param [0]}] call acex_fortify_fnc_addDeployValidator;
+ * [{alive param [0]}] call acex_fortify_fnc_addDeployHandler;
  *
  * Public: Yes
  */

--- a/addons/fortify/functions/fnc_addDeployHandler.sqf
+++ b/addons/fortify/functions/fnc_addDeployHandler.sqf
@@ -1,0 +1,22 @@
+/*
+ * Author: Cuel
+ * Register a custom deployment validator
+ * Provided code is passed [unit, object, cost]
+ * Code needs to return BOOL: true(allowed) / false(blocked)
+ *
+ * Arguments:
+ * 0: Code <CODE>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [{alive param [0]}] call acex_fortify_fnc_addDeployValidator;
+ *
+ * Public: Yes
+ */
+
+#include "script_component.hpp"
+params [["_code", {true}, [{}]]];
+
+GVAR(deployHandlers) pushBack _code;

--- a/addons/fortify/functions/fnc_deployObject.sqf
+++ b/addons/fortify/functions/fnc_deployObject.sqf
@@ -44,15 +44,24 @@ private _icons = [["alt", localize "str_3den_display3den_entitymenu_movesurface_
 [_lmb, _rmb, _wheel, _icons] call ACEFUNC(interaction,showMouseHint);
 
 private _mouseClickID = [_player, "DefaultAction", {GVAR(isPlacing) == PLACE_WAITING}, {GVAR(isPlacing) = PLACE_APPROVE}] call ACEFUNC(common,addActionEventHandler);
+[QGVAR(onDeployStart), [_player, _object, _cost]] call CBA_fnc_localEvent;
 
 [{
     params ["_args", "_pfID"];
     _args params ["_unit", "_object", "_cost", "_mouseClickID"];
 
-
     if ((_unit != ACE_player) || {isNull _object} || {!([_unit, _object, []] call ACEFUNC(common,canInteractWith))} || {!([_unit, _cost] call FUNC(canFortify))}) then {
         GVAR(isPlacing) = PLACE_CANCEL;
     };
+
+    if (GVAR(isPlacing) == PLACE_APPROVE) then {
+        // Run custom deploy handlers
+        private _someReturnFalse = {if ([_unit, _object, _cost] call _x isEqualTo false) exitWith {1}} count GVAR(deployHandlers);
+        if (_someReturnFalse isEqualTo 1) then {
+            GVAR(isPlacing) = PLACE_WAITING;
+        };
+    };
+
     if (GVAR(isPlacing) != PLACE_WAITING) exitWith {
         TRACE_3("exiting PFEH",GVAR(isPlacing),_pfID,_mouseClickID);
         [_pfID] call CBA_fnc_removePerFrameHandler;

--- a/addons/fortify/functions/fnc_deployObject.sqf
+++ b/addons/fortify/functions/fnc_deployObject.sqf
@@ -58,6 +58,7 @@ private _mouseClickID = [_player, "DefaultAction", {GVAR(isPlacing) == PLACE_WAI
         // Run custom deploy handlers
         private _someReturnFalse = {if ([_unit, _object, _cost] call _x isEqualTo false) exitWith {1}} count GVAR(deployHandlers);
         if (_someReturnFalse isEqualTo 1) then {
+            // do not allow placement
             GVAR(isPlacing) = PLACE_WAITING;
         };
     };


### PR DESCRIPTION
**When merged this pull request will:**
- Allow mission makers to register deployment handlers/validators so that they get more control of when a placement is possible. Inspired by ace explosives handlers.
- Adds a local event when deployment starts, e.g for displaying hints or possibilities of placement


Use case examples:
- Mission maker can control max height of placement
- Mission maker can check for nearby objects / disallow placing things too close