### PR TITLE
Killtracker: Add "Total Kills: <number>" to top of output.

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -120,4 +120,5 @@ Valentin Torikian <valentin.torikian@gmail.com>
 voiper
 VyMajoris(W-Cephei)<vycanismajoriscsa@gmail.com>
 Winter <simon@agius-muscat.net>
+wizpig64
 zGuba

--- a/addons/killtracker/XEH_postInit.sqf
+++ b/addons/killtracker/XEH_postInit.sqf
@@ -34,7 +34,7 @@ INFO("Running Kill Tracking");
 
 // Variables:
 GVAR(eventsArray) = [];
-GVAR(outputText) = "None";
+GVAR(outputText) = "Total Kills: 0";
 GVAR(killCount) = 0;
 
 // Add Event Handlers:

--- a/addons/killtracker/XEH_postInit.sqf
+++ b/addons/killtracker/XEH_postInit.sqf
@@ -35,20 +35,23 @@ INFO("Running Kill Tracking");
 // Variables:
 GVAR(eventsArray) = [];
 GVAR(outputText) = "None";
+GVAR(killCount) = 0;
 
 // Add Event Handlers:
 [QGVAR(kill), {
     params ["_name", "_killInfo"];
     TRACE_2("kill eh",_name,_killInfo);
+    // Increment kill counter
+    GVAR(killCount) = GVAR(killCount) + 1;
     GVAR(eventsArray) pushBack format ["Killed: %1 %2", _name, _killInfo];
-    GVAR(outputText) = (GVAR(eventsArray) joinString "<br/>");
+    GVAR(outputText) = (format ["Total Kills: %1<br/>", GVAR(killCount)]) + (GVAR(eventsArray) joinString "<br/>");
 }] call CBA_fnc_addEventHandler;
 
 [QGVAR(death), {
     params ["_name", "_killInfo"];
     TRACE_2("death eh",_name,_killInfo);
     GVAR(eventsArray) pushBack format ["Died: %1 %2", _name, _killInfo];
-    GVAR(outputText) = (GVAR(eventsArray) joinString "<br/>");
+    GVAR(outputText) = (format ["Total Kills: %1<br/>", GVAR(killCount)]) + (GVAR(eventsArray) joinString "<br/>");
 }] call CBA_fnc_addEventHandler;
 
 // Add Killed Event Handler - killed EH and lastDamageSource var are local only


### PR DESCRIPTION
This keeps track of the player's kills in a new killCount variable, and prepends the mission debrief text with "Total Kills: <number>".

Thanks!