### PR TITLE
Headless - Add preStart to CfgEventHandlers

### DIFF
--- a/addons/headless/CfgEventHandlers.hpp
+++ b/addons/headless/CfgEventHandlers.hpp
@@ -1,3 +1,9 @@
+class Extended_PreStart_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preStart));
+    };
+};
+
 class Extended_PreInit_EventHandlers {
     class ADDON {
         init = QUOTE(call COMPILE_FILE(XEH_preInit));


### PR DESCRIPTION
**When merged this pull request will:**
- `preStart` EH was missing from CfgEventHandlers
