### PR TITLE
View Restriction - Fix preserve view for vehicles with GUNNER view only

### DIFF
--- a/addons/viewrestriction/functions/fnc_canChangeCamera.sqf
+++ b/addons/viewrestriction/functions/fnc_canChangeCamera.sqf
@@ -5,6 +5,7 @@
  * Arguments:
  * 0: New Camera View <STRING>
  * 1: Vehicle <OBJECT>
+ * 2: Check gunner view <BOOL> (default: true)
  *
  * Return Value:
  * Can Change Camera <BOOL>
@@ -16,11 +17,12 @@
  */
 #include "script_component.hpp"
 
-params ["_newCameraView", "_cameraOn"];
+params ["_newCameraView", "_cameraOn", ["_checkGunnerView", true]];
 
 // Remote control hates switchCamera (control returns to player, camera is left on remotely controlled object/unit), make sure remote controlled units are not impacted
 
-!(_newCameraView in ["GUNNER", "GROUP"]) &&
+!(_newCameraView isEqualTo "GUNNER" && {_checkGunnerView}) &&
+{!(_newCameraView isEqualTo "GROUP")} &&
 {!isNull ACE_player} &&
 {player == ACE_player} &&
 {alive ACE_player} &&

--- a/addons/viewrestriction/functions/fnc_switchPreserveView.sqf
+++ b/addons/viewrestriction/functions/fnc_switchPreserveView.sqf
@@ -40,7 +40,7 @@ GVAR(preserveViewCameraViewEH) = ["cameraView", {
 GVAR(preserveViewVehicleEH) = ["vehicle", {
     params ["_player", "_vehicle"];
     private _cameraView = cameraView;
-    if !([_cameraView, cameraOn] call FUNC(canChangeCamera)) exitWith {};
+    if !([_cameraView, cameraOn, false] call FUNC(canChangeCamera)) exitWith {};
 
     private _vehicleClass = {if (_vehicle isKindOf _x) exitWith {_x}} forEach ["CAManBase", "LandVehicle", "Air", "Ship", "All"];
     private _savedView = profileNamespace getVariable (QGVAR(preserveView) + _vehicleClass);


### PR DESCRIPTION
**When merged this pull request will:**
- title.

Some vehicles (e.g. CUP Challenger 2) have only `GUNNER` view instead of `INTERNAL`. In such vehicles View Preserving doesn't work.