### PR TITLE
Fix error line numbers being wrong

### DIFF
--- a/addons/fortify/functions/fnc_addActions.sqf
+++ b/addons/fortify/functions/fnc_addActions.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Kingsley
  * Adds the child actions.
@@ -14,7 +15,6 @@
  * Public: No
  */
 
-#include "script_component.hpp"
 
 params ["_player"];
 

--- a/addons/fortify/functions/fnc_addDeployHandler.sqf
+++ b/addons/fortify/functions/fnc_addDeployHandler.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Cuel, mharis001
  * Adds a custom deploy handler.
@@ -15,7 +16,6 @@
  *
  * Public: Yes
  */
-#include "script_component.hpp"
 
 params [["_code", {}, [{}]]];
 

--- a/addons/fortify/functions/fnc_axisLengths.sqf
+++ b/addons/fortify/functions/fnc_axisLengths.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Kingsley
  * Gets the longest axis of the bounding box of the given object.
@@ -14,7 +15,6 @@
  * Public: Yes
  */
 
-#include "script_component.hpp"
 
 params [["_object", objNull, [objNull]]];
 

--- a/addons/fortify/functions/fnc_buildLocationModule.sqf
+++ b/addons/fortify/functions/fnc_buildLocationModule.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: PabstMirror
  * Handles build location module
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_logic"];
 TRACE_1("buildLocations",_logic);

--- a/addons/fortify/functions/fnc_canFortify.sqf
+++ b/addons/fortify/functions/fnc_canFortify.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Kingsley
  * Checks whether the given player can fortify.
@@ -15,7 +16,6 @@
  * Public: Yes
  */
 
-#include "script_component.hpp"
 
 params ["_player", ["_cost", 0]];
 

--- a/addons/fortify/functions/fnc_deployConfirm.sqf
+++ b/addons/fortify/functions/fnc_deployConfirm.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Kingsley
  * Confirms the deployment.
@@ -14,7 +15,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_unit", "_object"];
 TRACE_2("deployConfirm",_unit,_object);

--- a/addons/fortify/functions/fnc_deployObject.sqf
+++ b/addons/fortify/functions/fnc_deployObject.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Kingsley
  * Deploys the object to the player for them to move it around.
@@ -16,7 +17,6 @@
  * Public: No
  */
 
-#include "script_component.hpp"
 
 params ["", "_player", "_params"];
 _params params [["_side", sideUnknown, [sideUnknown]], ["_classname", "", [""]], ["_rotations", [0,0,0]]];

--- a/addons/fortify/functions/fnc_getBudget.sqf
+++ b/addons/fortify/functions/fnc_getBudget.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Kingsley
  * Gets the budget for the given side.
@@ -14,7 +15,6 @@
  * Public: Yes
  */
 
-#include "script_component.hpp"
 
 params ["_side"];
 

--- a/addons/fortify/functions/fnc_getCost.sqf
+++ b/addons/fortify/functions/fnc_getCost.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Kingsley
  * Gets the cost for the given side and classname.
@@ -15,7 +16,6 @@
  * Public: Yes
  */
 
-#include "script_component.hpp"
 
 params ["_side", "_classname"];
 

--- a/addons/fortify/functions/fnc_getPlaceableSet.sqf
+++ b/addons/fortify/functions/fnc_getPlaceableSet.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Kingsley
  * Gets placeable object classnames and values.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_preset"];
 TRACE_1("getPlaceableSet",_preset);

--- a/addons/fortify/functions/fnc_handleChatCommand.sqf
+++ b/addons/fortify/functions/fnc_handleChatCommand.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Kingsley
  * Handles the chat command usage by admin.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_args"];
 TRACE_1("handleChatCommand",_args);

--- a/addons/fortify/functions/fnc_handleScrollWheel.sqf
+++ b/addons/fortify/functions/fnc_handleScrollWheel.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Kingsley
  * Handles the object direction.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 if (GVAR(isPlacing) != PLACE_WAITING) exitWith {false};
 

--- a/addons/fortify/functions/fnc_modifyAction.sqf
+++ b/addons/fortify/functions/fnc_modifyAction.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
  /*
  * Author: PabstMirror
  * Modifies the fortify action, shows current budget.
@@ -16,7 +17,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["", "_player", "", "_actionData"];
 

--- a/addons/fortify/functions/fnc_parseSide.sqf
+++ b/addons/fortify/functions/fnc_parseSide.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Kingsley
  * Parses the given text and returns a side.
@@ -16,7 +17,6 @@
  * Public: Yes
  */
 
-#include "script_component.hpp"
 
 params ["_side"];
 TRACE_1("parseSide",_side);

--- a/addons/fortify/functions/fnc_registerObjects.sqf
+++ b/addons/fortify/functions/fnc_registerObjects.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Kingsley
  * Registers the given objects in the given side's player interaction menu.
@@ -19,7 +20,6 @@
  * Public: Yes
  */
 
-#include "script_component.hpp"
 
 if (!isServer) exitWith {};
 

--- a/addons/fortify/functions/fnc_setupModule.sqf
+++ b/addons/fortify/functions/fnc_setupModule.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: PabstMirror
  * Handles setup module.
@@ -15,7 +16,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_logic", "", "_activated"];
 TRACE_2("setupModule",_logic,_activated);

--- a/addons/fortify/functions/fnc_updateBudget.sqf
+++ b/addons/fortify/functions/fnc_updateBudget.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Kingsley
  * Updates the given sides budget.
@@ -16,7 +17,6 @@
  * Public: Yes
  */
 
-#include "script_component.hpp"
 
 params [["_side", sideUnknown, [sideUnknown]], ["_change", 0, [0]], ["_hint", true, [true]]];
 TRACE_3("updateBudget",_side,_change,_hint);

--- a/addons/headless/functions/fnc_endMissionNoPlayers.sqf
+++ b/addons/headless/functions/fnc_endMissionNoPlayers.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Ends mission on server if no players are connected.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 // Exit if players connected
 if !(call CBA_fnc_players isEqualTo []) exitWith {

--- a/addons/headless/functions/fnc_handleConnectHC.sqf
+++ b/addons/headless/functions/fnc_handleConnectHC.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Registers connected Headless Client for use.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_headlessClient"];
 

--- a/addons/headless/functions/fnc_handleDisconnect.sqf
+++ b/addons/headless/functions/fnc_handleDisconnect.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Removes Headless Client from use.
@@ -14,7 +15,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_object"];
 TRACE_1("HandleDisconnect",_this);

--- a/addons/headless/functions/fnc_handleSpawn.sqf
+++ b/addons/headless/functions/fnc_handleSpawn.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Handles AI spawn and requests a rebalance if applicable.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_object"];
 TRACE_1("Spawn",_object);

--- a/addons/headless/functions/fnc_moduleInit.sqf
+++ b/addons/headless/functions/fnc_moduleInit.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Initializes the Headless module.
@@ -12,7 +13,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_logic", "", "_activated"];
 

--- a/addons/headless/functions/fnc_rebalance.sqf
+++ b/addons/headless/functions/fnc_rebalance.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Rebalance AI groups accross HCs.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_force"];
 

--- a/addons/headless/functions/fnc_transferGroups.sqf
+++ b/addons/headless/functions/fnc_transferGroups.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Transfers AI groups to Headess Client(s).
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_force"];
 

--- a/addons/killtracker/XEH_postInit.sqf
+++ b/addons/killtracker/XEH_postInit.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: PabstMirror
  * Tracks deaths/kills and logs to the end mission disaplay
@@ -15,7 +16,6 @@
  * Public: No
  */
 // #define DEBUG_MODE_FULL
-#include "script_component.hpp"
 
 // place the following in a misison's description.ext:
 /*

--- a/addons/sitting/functions/fnc_addSitActions.sqf
+++ b/addons/sitting/functions/fnc_addSitActions.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Adds sit actions.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_seat"];
 

--- a/addons/sitting/functions/fnc_canSit.sqf
+++ b/addons/sitting/functions/fnc_canSit.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Check if the player can sit down.
@@ -14,7 +15,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_seat", "_player"];
 

--- a/addons/sitting/functions/fnc_canStand.sqf
+++ b/addons/sitting/functions/fnc_canStand.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Check if the player can stand up (is in sitting position).
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_player"];
 

--- a/addons/sitting/functions/fnc_getRandomAnimation.sqf
+++ b/addons/sitting/functions/fnc_getRandomAnimation.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Gets a random animations from the list.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 // Select random animation from Animations Pool
 selectRandom [

--- a/addons/sitting/functions/fnc_handleInterrupt.sqf
+++ b/addons/sitting/functions/fnc_handleInterrupt.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Handles interruptions of sitting, like killed or unconsciousness.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_player"];
 

--- a/addons/sitting/functions/fnc_moduleInit.sqf
+++ b/addons/sitting/functions/fnc_moduleInit.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Initializes the Sitting module.
@@ -12,7 +13,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_logic", "_units", "_activated"];
 

--- a/addons/sitting/functions/fnc_sit.sqf
+++ b/addons/sitting/functions/fnc_sit.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Sits down the player.
@@ -14,7 +15,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_seat", "_player"];
 

--- a/addons/sitting/functions/fnc_stand.sqf
+++ b/addons/sitting/functions/fnc_stand.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Stands up the player.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_player"];
 

--- a/addons/viewrestriction/functions/fnc_canChangeCamera.sqf
+++ b/addons/viewrestriction/functions/fnc_canChangeCamera.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Checks if camera can be changed.
@@ -14,7 +15,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_newCameraView", "_cameraOn"];
 

--- a/addons/viewrestriction/functions/fnc_changeCamera.sqf
+++ b/addons/viewrestriction/functions/fnc_changeCamera.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Change camera based on setting.
@@ -14,7 +15,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_newCameraView", "_cameraOn"];
 

--- a/addons/viewrestriction/functions/fnc_moduleInit.sqf
+++ b/addons/viewrestriction/functions/fnc_moduleInit.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Initializes the View Restriction module.
@@ -10,7 +11,6 @@
  * Return Value:
  * None
  */
-#include "script_component.hpp"
 
 params ["_logic", "_units", "_activated"];
 

--- a/addons/viewrestriction/functions/fnc_selectiveChangeCamera.sqf
+++ b/addons/viewrestriction/functions/fnc_selectiveChangeCamera.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Jonpas
  * Changes camera mode based on vehicle type the player is currently occupying.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_cameraOn"];
 

--- a/addons/viewrestriction/functions/fnc_switchPreserveView.sqf
+++ b/addons/viewrestriction/functions/fnc_switchPreserveView.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Dystopian
  * Controls View Preserving state.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 params ["_enabled"];
 

--- a/addons/volume/functions/fnc_lowerVolume.sqf
+++ b/addons/volume/functions/fnc_lowerVolume.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Kingsley
  * Lowers the game and music volume with values from ACE settings.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 ACEGVAR(hearing,disableVolumeUpdate) = true;
 

--- a/addons/volume/functions/fnc_remind.sqf
+++ b/addons/volume/functions/fnc_remind.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Kingsley
  * Reminds about lowered volume.
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 // Exit if reminder not enabled or not lowered
 if (!GVAR(remindIfLowered) || {!GVAR(isLowered)}) exitWith {};

--- a/addons/volume/functions/fnc_restoreVolume.sqf
+++ b/addons/volume/functions/fnc_restoreVolume.sqf
@@ -1,3 +1,4 @@
+#include "script_component.hpp"
 /*
  * Author: Kingsley
  * Restores the game and music volume to what it was when the mission first started,
@@ -13,7 +14,6 @@
  *
  * Public: No
  */
-#include "script_component.hpp"
 
 ACEGVAR(hearing,disableVolumeUpdate) = false;
 


### PR DESCRIPTION
**When merged this pull request will:**
- Do the same as https://github.com/acemod/ACE3/pull/6407 and https://github.com/CBATeam/CBA_A3/pull/937

Regex used:
```bash
find . -name '*.sqf' -type f -exec perl -0777 -pi -e 's/(.+)\#include\s\"script_component\.hpp\"\n/\#include \"script_component\.hpp\"\n\1/gs' -- {} +
```