### PR TITLE
Field Rations - Add CBA events for consuming items and refiling bottles

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -56,6 +56,7 @@ Coren <coren4@gmail.com>
 Crusty
 Dharma Bellamkonda <dharma.bellamkonda@gmail.com>
 Dimaslg <dimaslg@telecable.es>
+diwako
 dixon13 <dixonbegay@gmail.com>
 Drill <drill87@gmail.com>
 Dudakov aka [OMCB]Kaban <dudakov.s@gmail.com>

--- a/addons/field_rations/functions/fnc_consumeItem.sqf
+++ b/addons/field_rations/functions/fnc_consumeItem.sqf
@@ -91,8 +91,8 @@ private _fnc_onSuccess = {
         private _hunger = _player getVariable [QGVAR(hunger), 0];
         _player setVariable [QGVAR(hunger), (_hunger - _hungerSatiated) max 0];
     };
-	
-	[QGVAR(consumeItem), [_player, _consumeItem, _replacementItem, _thirstQuenched, _hungerSatiated]] call CBA_fnc_localEvent;
+
+    [QGVAR(consumeItem), [_player, _consumeItem, _replacementItem, _thirstQuenched, _hungerSatiated]] call CBA_fnc_localEvent;
 
     _player setVariable [QGVAR(previousAnim), nil];
 };

--- a/addons/field_rations/functions/fnc_consumeItem.sqf
+++ b/addons/field_rations/functions/fnc_consumeItem.sqf
@@ -91,6 +91,8 @@ private _fnc_onSuccess = {
         private _hunger = _player getVariable [QGVAR(hunger), 0];
         _player setVariable [QGVAR(hunger), (_hunger - _hungerSatiated) max 0];
     };
+	
+	[QGVAR(consumeItem), [_player, _consumeItem, _replacementItem, _thirstQuenched, _hungerSatiated]] call CBA_fnc_localEvent;
 
     _player setVariable [QGVAR(previousAnim), nil];
 };

--- a/addons/field_rations/functions/fnc_consumeItem.sqf
+++ b/addons/field_rations/functions/fnc_consumeItem.sqf
@@ -92,7 +92,7 @@ private _fnc_onSuccess = {
         _player setVariable [QGVAR(hunger), (_hunger - _hungerSatiated) max 0];
     };
 
-    [QGVAR(consumeItem), [_player, _consumeItem, _replacementItem, _thirstQuenched, _hungerSatiated]] call CBA_fnc_localEvent;
+    ["acex_rationConsumed", [_player, _consumeItem, _replacementItem, _thirstQuenched, _hungerSatiated]] call CBA_fnc_localEvent;
 
     _player setVariable [QGVAR(previousAnim), nil];
 };

--- a/addons/field_rations/functions/fnc_refillItem.sqf
+++ b/addons/field_rations/functions/fnc_refillItem.sqf
@@ -43,7 +43,7 @@ private _fnc_onSuccess = {
         [_source, _waterInSource] call FUNC(setRemainingWater);
     };
 
-    [QGVAR(refillItem), [_source, _player, _item, _refillItem, _refillAmount]] call CBA_fnc_localEvent;
+    ["acex_rationRefilled", [_source, _player, _item, _refillItem, _refillAmount]] call CBA_fnc_localEvent;
 
     // Show refilled item hint
     private _picture = getText (configFile >> "CfgWeapons" >> _refillItem >> "picture");

--- a/addons/field_rations/functions/fnc_refillItem.sqf
+++ b/addons/field_rations/functions/fnc_refillItem.sqf
@@ -43,6 +43,8 @@ private _fnc_onSuccess = {
         [_source, _waterInSource] call FUNC(setRemainingWater);
     };
 
+    [QGVAR(refillItem), [_source, _player, _item, _refillItem, _refillAmount]] call CBA_fnc_localEvent;
+
     // Show refilled item hint
     private _picture = getText (configFile >> "CfgWeapons" >> _refillItem >> "picture");
     [LSTRING(ItemRefilled), _picture] call ACEFUNC(common,displayTextPicture);


### PR DESCRIPTION
**When merged this pull request will:**
Adds local CBA events when consuming items or refilling items.

Reason for this is, there is no way to interact with this so far on mission level. If someone wants to manipulate how much an item quenches thirst or how much hunger is sated it has to be done via mod right now.
This also means scripters can add their own logic when someone consumes a certain item or refills at a certain water source.
