### PR TITLE
Field Rations - Add setting to control effect on advanced fatigue

### DIFF
--- a/addons/field_rations/XEH_postInit.sqf
+++ b/addons/field_rations/XEH_postInit.sqf
@@ -9,7 +9,7 @@ if !(hasInterface) exitWith {};
     // Add Advanced Fatigue duty factor
     if (GVAR(affectAdvancedFatigue) && {missionNamespace getVariable [QACEGVAR(advanced_fatigue,enabled), false]}) then {
         [QUOTE(ADDON), {
-            linearConversion [50, 100, _this getVariable [QGVAR(thirst), 0], 1, 1.4, true] * linearConversion [50, 100, _this getVariable [QGVAR(hunger), 0], 1, 1.1, true];
+            linearConversion [50, 100, _this getVariable [QGVAR(thirst), 0], 1, 1.4, true] * linearConversion [50, 100, _this getVariable [QGVAR(hunger), 0], 1, 1.1, true]
         }] call ACEFUNC(advanced_fatigue,addDutyFactor);
         TRACE_1("Added duty factor",GVAR(affectAdvancedFatigue));
     };

--- a/addons/field_rations/XEH_postInit.sqf
+++ b/addons/field_rations/XEH_postInit.sqf
@@ -7,11 +7,11 @@ if !(hasInterface) exitWith {};
     if (!GVAR(enabled)) exitWith {};
 
     // Add Advanced Fatigue duty factor
-    if (missionNamespace getVariable [QACEGVAR(advanced_fatigue,enabled), false]) then {
-        LOG("Adding Duty Factor");
+    if (GVAR(affectAdvancedFatigue) && {missionNamespace getVariable [QACEGVAR(advanced_fatigue,enabled), false]}) then {
         [QUOTE(ADDON), {
-            (linearConversion [0, 75, _this getVariable [QGVAR(thirst), 0], 1, 2, true]) * (linearConversion [0, 60, _this getVariable [QGVAR(hunger), 0], 1, 1.5, true])
+            linearConversion [50, 100, _this getVariable [QGVAR(thirst), 0], 1, 1.4, true] * linearConversion [50, 100, _this getVariable [QGVAR(hunger), 0], 1, 1.1, true];
         }] call ACEFUNC(advanced_fatigue,addDutyFactor);
+        TRACE_1("Added duty factor",GVAR(affectAdvancedFatigue));
     };
 
     // Compile water source actions

--- a/addons/field_rations/initSettings.sqf
+++ b/addons/field_rations/initSettings.sqf
@@ -28,6 +28,33 @@
 ] call CBA_settings_fnc_init;
 
 [
+    QGVAR(thirstQuenched),
+    "SLIDER",
+    [LSTRING(ThirstQuenched_DisplayName), LSTRING(ThirstQuenched_Description)],
+    LSTRING(DisplayName),
+    [0.1, 10, 1, 1],
+    true
+] call CBA_settings_fnc_init;
+
+[
+    QGVAR(hungerSatiated),
+    "SLIDER",
+    [LSTRING(HungerSatiated_DisplayName), LSTRING(HungerSatiated_Description)],
+    LSTRING(DisplayName),
+    [0.1, 10, 1, 1],
+    true
+] call CBA_settings_fnc_init;
+
+[
+    QGVAR(affectAdvancedFatigue),
+    "CHECKBOX",
+    [LSTRING(AffectAdvancedFatigue_DisplayName), LSTRING(AffectAdvancedFatigue_Description)],
+    LSTRING(DisplayName),
+    true,
+    true
+] call CBA_settings_fnc_init;
+
+[
     QGVAR(hudType),
     "LIST",
     [LSTRING(HudType_DisplayName), LSTRING(HudType_Description)],
@@ -52,22 +79,4 @@
     LSTRING(DisplayName),
     [[-1, 0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8], [LSTRING(Dynamic), "0%", "10%", "20%", "30%", "40%", "50%", "60%", "70%", "80%", 0], 0],
     false
-] call CBA_settings_fnc_init;
-
-[
-    QGVAR(thirstQuenched),
-    "SLIDER",
-    [LSTRING(thirstQuenched_DisplayName), LSTRING(thirstQuenched_Description)],
-    LSTRING(DisplayName),
-    [0.1, 10, 1, 1],
-    true
-] call CBA_settings_fnc_init;
-
-[
-    QGVAR(hungerSatiated),
-    "SLIDER",
-    [LSTRING(hungerSatiated_DisplayName), LSTRING(hungerSatiated_Description)],
-    LSTRING(DisplayName),
-    [0.1, 10, 1, 1],
-    true
 ] call CBA_settings_fnc_init;

--- a/addons/field_rations/stringtable.xml
+++ b/addons/field_rations/stringtable.xml
@@ -55,7 +55,7 @@
             <Spanish>Supervivencia</Spanish>
         </Key>
         <Key ID="STR_ACEX_Field_Rations_Enabled_Description">
-            <English>Enable/Disable field rations</English>
+            <English>Enable/Disable Field Rations</English>
             <Chinese>啟用/禁用字段口糧</Chinese>
             <Chinesesimp>启用/禁用字段口粮</Chinesesimp>
             <Czech>Povolit / zakázat příděly v polích</Czech>
@@ -71,7 +71,7 @@
             <Spanish>Habilitar / deshabilitar las raciones de campo</Spanish>
         </Key>
         <Key ID="STR_ACEX_Field_Rations_TimeWithoutWater_DisplayName">
-            <English>Time without water</English>
+            <English>Time Without Water</English>
             <Chinese>沒有水的時候</Chinese>
             <Chinesesimp>没有水的时候</Chinesesimp>
             <Czech>Czas bez wody</Czech>
@@ -103,7 +103,7 @@
             <Spanish>¿Cuánto tiempo debería una unidad ir sin agua (horas)?</Spanish>
         </Key>
         <Key ID="STR_ACEX_Field_Rations_TimeWithoutFood_DisplayName">
-            <English>Time without food</English>
+            <English>Time Without Food</English>
             <Chinese>沒有食物的時間</Chinese>
             <Chinesesimp>没有食物的时间</Chinesesimp>
             <Czech>Čas bez jídla</Czech>
@@ -134,17 +134,23 @@
             <Russian>Как долго подразделение сможет идти без пищи (часы)</Russian>
             <Spanish>¿Cuánto tiempo debería una unidad ir sin comida (horas)?</Spanish>
         </Key>
-        <Key ID="STR_ACEX_Field_Rations_thirstQuenched_DisplayName">
-            <English>Thirst quenched</English>
+        <Key ID="STR_ACEX_Field_Rations_ThirstQuenched_DisplayName">
+            <English>Thirst Quenched</English>
         </Key>
-        <Key ID="STR_ACEX_Field_Rations_thirstQuenched_Description">
+        <Key ID="STR_ACEX_Field_Rations_ThirstQuenched_Description">
             <English>Coefficient for the amount of thirst quenched from drinking</English>
         </Key>
-        <Key ID="STR_ACEX_Field_Rations_hungerSatiated_DisplayName">
-            <English>Hunger satiated</English>
+        <Key ID="STR_ACEX_Field_Rations_HungerSatiated_DisplayName">
+            <English>Hunger Satiated</English>
         </Key>
-        <Key ID="STR_ACEX_Field_Rations_hungerSatiated_Description">
+        <Key ID="STR_ACEX_Field_Rations_HungerSatiated_Description">
             <English>Coefficient for the amount of hunger satiated from eating</English>
+        </Key>
+        <Key ID="STR_ACEX_Field_Rations_AffectAdvancedFatigue_DisplayName">
+            <English>Affect Advanced Fatigue</English>
+        </Key>
+        <Key ID="STR_ACEX_Field_Rations_AffectAdvancedFatigue_Description">
+            <English>Controls if thirst and hunger should affect ACE Advanced Fatigue</English>
         </Key>
         <Key ID="STR_ACEX_Field_Rations_HudType_DisplayName">
             <English>HUD Type</English>


### PR DESCRIPTION
**When merged this pull request will:**
- Add `affectAdvancedFatigue` setting
- Change duty factor values to something more reasonable
    - Based on observations after playing with system, old values drained stamina too quickly once thirst got high
    - Goal is to have a noticeable effect when thirst is high without completely destroying stamina
- Capitalize setting names
