### PR TITLE
Field Rations - Fix changing HUD type while HUD is shown

### DIFF
--- a/addons/field_rations/initSettings.sqf
+++ b/addons/field_rations/initSettings.sqf
@@ -60,7 +60,10 @@
     [LSTRING(HudType_DisplayName), LSTRING(HudType_Description)],
     LSTRING(DisplayName),
     [[0, 1], [LSTRING(ColoredIcons), LSTRING(DrainingIcons)], 0],
-    false
+    false,
+    {
+        QGVAR(hud) cutFadeOut 0;
+    }
 ] call CBA_settings_fnc_init;
 
 [


### PR DESCRIPTION
**When merged this pull request will:**
- title, close currently active HUD whenever setting changes to force `handleHUD` function to create new HUD type