### PR TITLE
Field Rations - Disable for virtual units, Hide HUD in feature cameras

### DIFF
--- a/addons/field_rations/XEH_postInit.sqf
+++ b/addons/field_rations/XEH_postInit.sqf
@@ -93,7 +93,7 @@ if !(hasInterface) exitWith {};
         }] call FUNC(addStatusModifier);
     };
 
-    // Handle returning to normal transparency once interaction action is closed
+    // Handle returning to normal transparency once interaction menu is closed
     GVAR(hudInteractionHover) = false;
 
     ["ace_interactMenuClosed", {

--- a/addons/field_rations/XEH_postInit.sqf
+++ b/addons/field_rations/XEH_postInit.sqf
@@ -93,6 +93,7 @@ if !(hasInterface) exitWith {};
         }] call FUNC(addStatusModifier);
     };
 
+    // Handle returning to normal transparency once interaction action is closed
     GVAR(hudInteractionHover) = false;
 
     ["ace_interactMenuClosed", {

--- a/addons/field_rations/functions/fnc_handleHUD.sqf
+++ b/addons/field_rations/functions/fnc_handleHUD.sqf
@@ -36,7 +36,9 @@ if (GVAR(hudType) == 0) then {
     };
 
     // Reduce transparency if hovering on interaction
-    _fade = _fade min ([1, 0.5] select GVAR(hudInteractionHover));
+    if (GVAR(hudInteractionHover)) then {
+        _fade = _fade min 0.5;
+    };
 
     // Update HUD icon colors (White -> Yellow -> Orange -> Red)
     {

--- a/addons/field_rations/functions/fnc_update.sqf
+++ b/addons/field_rations/functions/fnc_update.sqf
@@ -23,8 +23,8 @@ params ["_nextMpSync"];
 // Access global variable once
 private _player = ACE_player;
 
-// Handle unit not alive or null
-if (!alive _player) exitWith {
+// Exit if player is not alive or a virtual unit
+if (!alive _player || {_player isKindOf "VirtualMan_F"}) exitWith {
     [FUNC(update), _nextMpSync, 1] call CBA_fnc_waitAndExecute;
     QGVAR(hud) cutFadeOut 0.5;
 };
@@ -53,6 +53,7 @@ _hunger = _hunger + _hungerChange min 100 max 0;
 
 // Check if we want to do a MP sync
 private _doSync = false;
+
 if (CBA_missionTime >= _nextMpSync) then {
     _doSync = true;
     _nextMpSync = CBA_missionTime + MP_SYNC_INTERVAL;
@@ -66,7 +67,7 @@ _player setVariable [QGVAR(hunger), _hunger, _doSync];
 [_player, _thirst, _hunger] call FUNC(handleEffects);
 
 // Handle showing/updating or hiding of HUD
-if (_thirst > GVAR(hudShowLevel) || {_hunger > GVAR(hudShowLevel)} || {GVAR(hudInteractionHover)}) then {
+if (!ACEGVAR(common,OldIsCamera) && {_thirst > GVAR(hudShowLevel) || {_hunger > GVAR(hudShowLevel)} || {GVAR(hudInteractionHover)}}) then {
     [_thirst, _hunger] call FUNC(handleHUD);
 } else {
     QGVAR(hud) cutFadeOut 0.5;


### PR DESCRIPTION
**When merged this pull request will:**
- Disable thirst and hunger for virtual units `VirtualMan_F`
- Hide HUD while a feature camera is active
- Close #182 , Close #187 