### PR TITLE
Fortify - Fix interaction overlapping remove object interaction

### DIFF
--- a/addons/fortify/XEH_postInit.sqf
+++ b/addons/fortify/XEH_postInit.sqf
@@ -60,6 +60,6 @@ GVAR(objectRotationZ) = 0;
             5
         ] call ACEFUNC(interact_menu,createAction);
 
-        [_object, 0, [], _removeAction] call ACEFUNC(interact_menu,addActionToObject);
+        [_object, 0, ["ACE_MainActions"], _removeAction] call ACEFUNC(interact_menu,addActionToObject);
     };
 }] call CBA_fnc_addEventHandler;


### PR DESCRIPTION
Hello,
Not sure at all if it is resolving this issue Fixes #209
Not tested!

**When merged this pull request will:**
- fortify remove action is added with a parent path `"ACE_MainActions"`
- Add `"ACE_MainActions"` in `ace_interact_menu_fnc_addActionToObject` (https://ace3mod.com/wiki/framework/interactionMenu-framework.html#33-fnc_addactiontoobject)