### PR TITLE
Field Rations - Fix interaction overlapping Check Remaining Water

### DIFF
--- a/addons/field_rations/XEH_postInit.sqf
+++ b/addons/field_rations/XEH_postInit.sqf
@@ -68,7 +68,7 @@ if !(hasInterface) exitWith {};
     ];
 
     // Add water source actions to helper
-    [QGVAR(helper), 0, [], _mainAction] call ACEFUNC(interact_menu,addActionToClass);
+    [QGVAR(helper), 0, ["ACE_MainActions"], _mainAction] call ACEFUNC(interact_menu,addActionToClass);
     {
         [QGVAR(helper), 0, [QGVAR(waterSource)], _x] call ACEFUNC(interact_menu,addActionToClass);
     } forEach _subActions;


### PR DESCRIPTION
Hello,
Not sure at all if it is resolving this issue Fixes #174
Not tested!

**When merged this pull request will:**
- Check Remaining Water text action is added with a parent path `"ACE_MainActions"`
- Add `"ACE_MainActions"` in `ace_interact_menu_fnc_addActionToObject` (https://ace3mod.com/wiki/framework/interactionMenu-framework.html#33-fnc_addactiontoobject)
- Same bug as https://github.com/acemod/ACEX/issues/209