### PR TITLE
Tools - Use `GITHUB_TOKEN` in documentation workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - master
+    - fix-ci-docs
 
 jobs:
   update:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -20,5 +20,5 @@ jobs:
     - name: Deploy
       if: github.repository == 'acemod/ACEX' && ! contains(github.event.head_commit.message, '[ci skip]')
       env:
-        GH_TOKEN: ${{ secrets.DOCS_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: python3 tools/deploy.py

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - master
-    - fix-ci-docs
 
 jobs:
   update:


### PR DESCRIPTION
**When merged this pull request will:**
- Title

No need for any more permissions than this token provides as we are not pushing anything to the repository like in ACE3 (wiki updates).