### PR TITLE
Intel Items - Fix addIntel addMagazine locality

### DIFF
--- a/addons/intelitems/functions/fnc_addIntel.sqf
+++ b/addons/intelitems/functions/fnc_addIntel.sqf
@@ -33,7 +33,7 @@ if (
 
 // Add the magazine item to the unit's inventory and get its id
 private _magazinesBefore = [_unit, _item] call CBA_fnc_getMagazineIndex;
-_unit addMagazine _item;
+_unit addMagazine [_item, 2];
 private _magazinesAfter = [_unit, _item] call CBA_fnc_getMagazineIndex;
 
 private _magazineId = _magazinesAfter - _magazinesBefore;

--- a/addons/intelitems/functions/fnc_addIntel.sqf
+++ b/addons/intelitems/functions/fnc_addIntel.sqf
@@ -33,7 +33,7 @@ if (
 
 // Add the magazine item to the unit's inventory and get its id
 private _magazinesBefore = [_unit, _item] call CBA_fnc_getMagazineIndex;
-_unit addMagazine [_item, 2];
+_unit addMagazine [_item, 1];
 private _magazinesAfter = [_unit, _item] call CBA_fnc_getMagazineIndex;
 
 private _magazineId = _magazinesAfter - _magazinesBefore;


### PR DESCRIPTION
**When merged this pull request will:**
- `unitName addMagazine magazineName` -> needs local argument, but is executed on the server (https://community.bistudio.com/wiki/addMagazine)
- `[ACE_player, "acex_intelitems_notepad", "Notes!"] remoteExec ["acex_intelitems_fnc_addIntel", 2]` didnt work because of this on DS
- works on EditorMultiplayer because player == server == local argument
- fixes #203 please review @mharis001 