### PR TITLE
Make Thirst Quenched Coefficient Effect Water Sources

### DIFF
--- a/addons/field_rations/functions/fnc_drinkFromSource.sqf
+++ b/addons/field_rations/functions/fnc_drinkFromSource.sqf
@@ -30,7 +30,7 @@ private _fnc_onSuccess = {
 
     // Reduce player thirst
     private _thirst = _player getVariable [QGVAR(thirst), 0];
-    _player setVariable [QGVAR(thirst), (_thirst - DRINK_FROM_SOURCE_QUENCHED) max 0];
+    _player setVariable [QGVAR(thirst), (_thirst - (DRINK_FROM_SOURCE_QUENCHED * GVAR(thirstQuenched))) max 0];
     _player setVariable [QGVAR(previousAnim), nil];
 
     // Update remaining water in source


### PR DESCRIPTION
**When merged this pull request will:**
- Title

We have a high thirst quenched modifier. Today a fireteam noticed that filling their canteens and drinking from those is way more efficient for some reason 😄 