### PR TITLE
Fortify - Fix legacy module support

### DIFF
--- a/addons/fortify/functions/fnc_setupModule.sqf
+++ b/addons/fortify/functions/fnc_setupModule.sqf
@@ -35,7 +35,7 @@ _side = switch (_side) do {
 };
 
 private _preset = _logic getVariable ["Preset", "small"];
-if IS_NUMBER(preset) then { // Legacy support
+if IS_NUMBER(_preset) then { // Legacy support
     _preset = switch (_preset) do {
         case 1: {"small"};
         case 2: {"medium"};


### PR DESCRIPTION
```
Error in expression <ionConfigFile >> "ACEX_Fortify_Presets" >> _preset;
File z\acex\addons\fortify\functions\fnc_getPlaceableSet.sqf..., line 21
```

This breaks inside of a execNextFrame during CBA settings, and repeats forever