### PR TITLE
Fortify: Add map area markers for ACEX Fortify Objects

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -125,3 +125,4 @@ VyMajoris(W-Cephei)<vycanismajoriscsa@gmail.com>
 Winter <simon@agius-muscat.net>
 wizpig64
 zGuba
+Seb <sebsmith90@gmail.com>

--- a/addons/fortify/XEH_PREP.hpp
+++ b/addons/fortify/XEH_PREP.hpp
@@ -17,3 +17,4 @@ PREP(getPlaceableSet);
 PREP(modifyAction);
 PREP(setupModule);
 PREP(buildLocationModule);
+PREP(createObjectMarker);

--- a/addons/fortify/XEH_postInit.sqf
+++ b/addons/fortify/XEH_postInit.sqf
@@ -10,7 +10,12 @@ if (isServer) then {
         private _jipID = [QGVAR(addActionToObject), [_side, _object]] call CBA_fnc_globalEventJIP;
         [_jipID, _object] call CBA_fnc_removeGlobalEventJIP; // idealy this function should be called on the server
         if (GVAR(markObjectsOnMap) isNotEqualTo 0 && {_object isKindOf "Static"}) then {
-            [_object] call FUNC(createObjectMarker)
+            // Wait ensures correct marker pos/rot as object is moved into position after creation
+            [
+                {_this call FUNC(createObjectMarker)}, 
+                _object,
+                1
+            ] call CBA_fnc_waitAndExecute;
         };
     }] call CBA_fnc_addEventHandler;
 };

--- a/addons/fortify/XEH_postInit.sqf
+++ b/addons/fortify/XEH_postInit.sqf
@@ -95,7 +95,6 @@ GVAR(objectRotationZ) = 0;
 
 // Reset map marker alphas when the side of the controlled unit changes.
 ["group", {
-    systemChat "Running map change";
     {
         private _object = _y;
         [QGVAR(setMarkerVisible), _object] call CBA_fnc_localEvent;

--- a/addons/fortify/XEH_postInit.sqf
+++ b/addons/fortify/XEH_postInit.sqf
@@ -71,7 +71,7 @@ GVAR(objectRotationZ) = 0;
         {!isNull player},
         {
             params ["_object"];
-            if (GVAR(markObjectsOnMap) isEqualTo 2 || {[_object getVariable QGVAR(objectSide), side group player] call BIS_fnc_sideIsEnemy}) then {
+            if (GVAR(markObjectsOnMap) isEqualTo 1 || {[_object getVariable QGVAR(objectSide), side group player] call BIS_fnc_sideIsEnemy}) then {
                 private _marker = _object getVariable QGVAR(mapMarker);
                 _marker setMarkerAlpha 0;
             };

--- a/addons/fortify/XEH_postInit.sqf
+++ b/addons/fortify/XEH_postInit.sqf
@@ -7,6 +7,7 @@ if (isServer) then {
         TRACE_3("objectPlaced",_unit,_side,_object);
         private _jipID = [QGVAR(addActionToObject), [_side, _object]] call CBA_fnc_globalEventJIP;
         [_jipID, _object] call CBA_fnc_removeGlobalEventJIP; // idealy this function should be called on the server
+        if (GVAR(markObjectsOnMap) isNotEqualTo 0 && {_object isKindOf "Static"}) then {[_object] call FUNC(createObjectMarker)};
     }] call CBA_fnc_addEventHandler;
 };
 
@@ -62,4 +63,19 @@ GVAR(objectRotationZ) = 0;
 
         [_object, 0, ["ACE_MainActions"], _removeAction] call ACEFUNC(interact_menu,addActionToObject);
     };
+}] call CBA_fnc_addEventHandler;
+
+[QGVAR(setMarkerVisible), {
+    params ["_object"];
+    [
+        {!isNull player},
+        {
+            params ["_object"];
+            if (GVAR(markObjectsOnMap) isEqualTo 2 || {[_object getVariable QGVAR(objectSide), side group player] call BIS_fnc_sideIsEnemy}) then {
+                private _marker = _object getVariable QGVAR(mapMarker);
+                _marker setMarkerAlpha 0;
+            };
+        }, 
+        _object
+    ] call CBA_fnc_waitUntilAndExecute;
 }] call CBA_fnc_addEventHandler;

--- a/addons/fortify/XEH_postInit.sqf
+++ b/addons/fortify/XEH_postInit.sqf
@@ -76,7 +76,7 @@ GVAR(objectRotationZ) = 0;
             private _objectSide = _object getVariable QGVAR(objectSide);
             private _playerSide = side group player;
             // If enemy placed object, hide marker.
-            if (GVAR(markObjectsOnMap) isNotEqualTo 2 || {_objectSide getFriend _playerSide < 0.6}) then {
+            if (GVAR(markObjectsOnMap) isEqualTo 1 && {_objectSide getFriend _playerSide < 0.6}) then {
                 private _marker = _object getVariable QGVAR(mapMarker);
                 _marker setMarkerAlpha 0;
             };

--- a/addons/fortify/XEH_postInit.sqf
+++ b/addons/fortify/XEH_postInit.sqf
@@ -78,7 +78,7 @@ GVAR(objectRotationZ) = 0;
             // If enemy placed object, hide marker.
             if (GVAR(markObjectsOnMap) isEqualTo 1 && {_objectSide getFriend _playerSide < 0.6}) then {
                 private _marker = _object getVariable QGVAR(mapMarker);
-                _marker setMarkerAlpha 0;
+                _marker setMarkerAlphaLocal 0;
             };
         }, 
         _object

--- a/addons/fortify/XEH_postInit.sqf
+++ b/addons/fortify/XEH_postInit.sqf
@@ -76,7 +76,7 @@ GVAR(objectRotationZ) = 0;
             private _objectSide = _object getVariable QGVAR(objectSide);
             private _playerSide = side group player;
             // If enemy placed object, hide marker.
-            if (GVAR(markObjectsOnMap) isEqualTo 1 || {_objectSide getFriend _playerSide < 0.6}) then {
+            if (GVAR(markObjectsOnMap) isNotEqualTo 2 || {_objectSide getFriend _playerSide < 0.6}) then {
                 private _marker = _object getVariable QGVAR(mapMarker);
                 _marker setMarkerAlpha 0;
             };

--- a/addons/fortify/XEH_postInit.sqf
+++ b/addons/fortify/XEH_postInit.sqf
@@ -7,7 +7,9 @@ if (isServer) then {
         TRACE_3("objectPlaced",_unit,_side,_object);
         private _jipID = [QGVAR(addActionToObject), [_side, _object]] call CBA_fnc_globalEventJIP;
         [_jipID, _object] call CBA_fnc_removeGlobalEventJIP; // idealy this function should be called on the server
-        if (GVAR(markObjectsOnMap) isNotEqualTo 0 && {_object isKindOf "Static"}) then {[_object] call FUNC(createObjectMarker)};
+        if (GVAR(markObjectsOnMap) isNotEqualTo 0 && {_object isKindOf "Static"}) then {
+            [_object] call FUNC(createObjectMarker)
+        };
     }] call CBA_fnc_addEventHandler;
 };
 
@@ -71,7 +73,10 @@ GVAR(objectRotationZ) = 0;
         {!isNull player},
         {
             params ["_object"];
-            if (GVAR(markObjectsOnMap) isEqualTo 1 || {[_object getVariable QGVAR(objectSide), side group player] call BIS_fnc_sideIsEnemy}) then {
+            private _objectSide = _object getVariable QGVAR(objectSide);
+            private _playerSide = side group player;
+            // If enemy placed object, hide marker.
+            if (GVAR(markObjectsOnMap) isEqualTo 1 || {_objectSide getFriend _playerSide < 0.6}) then {
                 private _marker = _object getVariable QGVAR(mapMarker);
                 _marker setMarkerAlpha 0;
             };

--- a/addons/fortify/functions/fnc_createObjectMarker.sqf
+++ b/addons/fortify/functions/fnc_createObjectMarker.sqf
@@ -1,0 +1,49 @@
+#include "script_component.hpp"
+
+/*
+ * Author: Seb
+ * Creates a map marker for a created static object but only for sides friendly to the creator side
+ *
+ * Arguments:
+ * 0: Created fortify object <OBJECT>
+ * 1: Friendly side
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [_object, _side] call acex_fortify_fnc_createObjectMarker
+ *
+ * Public: Yes
+ */
+
+params ["_object"];
+
+// Get Object size and direction
+private _bbr = 0 boundingBoxReal _object;
+private _p1 = _bbr select 0;
+private _p2 = _bbr select 1;
+private _maxWidth = abs ((_p2 select 0) - (_p1 select 0));
+private _maxLength = abs ((_p2 select 1) - (_p1 select 1));
+private _direction = getDir _object;
+
+// Marker name unique to this trench object
+private _markerNameStr = format ["acex_fortify_marker_%1", _object];
+
+// Create marker, but only for side of trench placer
+private _marker = createMarker [_markerNameStr, _object];
+_marker setMarkerShapeLocal "RECTANGLE";
+_marker setMarkerBrushLocal "SolidFull";
+_marker setMarkerSizeLocal [(_maxWidth / 2),(_maxLength / 2)];
+_marker setMarkerDirLocal _direction;
+_marker setMarkerColor "ColorGrey";
+_object setVariable [QGVAR(mapMarker), _marker, true];
+// Marker Alpha set in EH:
+private _jipID = [QGVAR(setMarkerVisible), _object] call CBA_fnc_globalEventJIP;
+[_jipID, _object] call CBA_fnc_removeGlobalEventJIP;
+
+_object addEventHandler ["Deleted", {
+    params ["_object"];
+    private _marker = _object getVariable QGVAR(mapMarker);
+    deleteMarker _marker;
+}];

--- a/addons/fortify/functions/fnc_createObjectMarker.sqf
+++ b/addons/fortify/functions/fnc_createObjectMarker.sqf
@@ -26,7 +26,7 @@ private _maxWidth = abs ((_p2 select 0) - (_p1 select 0));
 private _maxLength = abs ((_p2 select 1) - (_p1 select 1));
 private _direction = getDir _object;
 
-// Marker name unique to this object
+// Marker name unique to this object, add it to a hashmap that matches map markers to objects.
 private _markerNameStr = format [QGVAR(marker_%1), _object];
 
 // Create marker, set alpha using global event
@@ -37,12 +37,18 @@ _marker setMarkerSizeLocal [(_maxWidth / 2),(_maxLength / 2)];
 _marker setMarkerDirLocal _direction;
 _marker setMarkerColor "ColorGrey";
 _object setVariable [QGVAR(mapMarker), _marker, true];
+
 // Marker Alpha set in EH:
 private _jipID = [QGVAR(setMarkerVisible), _object] call CBA_fnc_globalEventJIP;
 [_jipID, _object] call CBA_fnc_removeGlobalEventJIP;
 
+GVAR(markerObjectHashmap) set [_marker, _object];
+publicVariable QGVAR(markerObjectHashmap);
+
 _object addEventHandler ["Deleted", {
     params ["_object"];
     private _marker = _object getVariable QGVAR(mapMarker);
+    GVAR(markerObjectHashmap) deleteAt _marker;
     deleteMarker _marker;
+    publicVariable QGVAR(markerObjectHashmap);
 }];

--- a/addons/fortify/functions/fnc_createObjectMarker.sqf
+++ b/addons/fortify/functions/fnc_createObjectMarker.sqf
@@ -2,7 +2,7 @@
 
 /*
  * Author: Seb
- * Creates a map marker for a created static object but only for sides friendly to the creator side
+ * Creates a map marker for a created static object but only for sides friendly to the creator side.
  *
  * Arguments:
  * 0: Created fortify object <OBJECT>

--- a/addons/fortify/functions/fnc_createObjectMarker.sqf
+++ b/addons/fortify/functions/fnc_createObjectMarker.sqf
@@ -6,13 +6,12 @@
  *
  * Arguments:
  * 0: Created fortify object <OBJECT>
- * 1: Friendly side
  *
  * Return Value:
  * None
  *
  * Example:
- * [_object, _side] call acex_fortify_fnc_createObjectMarker
+ * _object call acex_fortify_fnc_createObjectMarker
  *
  * Public: Yes
  */
@@ -27,10 +26,10 @@ private _maxWidth = abs ((_p2 select 0) - (_p1 select 0));
 private _maxLength = abs ((_p2 select 1) - (_p1 select 1));
 private _direction = getDir _object;
 
-// Marker name unique to this trench object
+// Marker name unique to this object
 private _markerNameStr = format ["acex_fortify_marker_%1", _object];
 
-// Create marker, but only for side of trench placer
+// Create marker, set alpha using global event
 private _marker = createMarker [_markerNameStr, _object];
 _marker setMarkerShapeLocal "RECTANGLE";
 _marker setMarkerBrushLocal "SolidFull";

--- a/addons/fortify/functions/fnc_createObjectMarker.sqf
+++ b/addons/fortify/functions/fnc_createObjectMarker.sqf
@@ -13,7 +13,7 @@
  * Example:
  * _object call acex_fortify_fnc_createObjectMarker
  *
- * Public: Yes
+ * Public: No
  */
 
 params ["_object"];
@@ -27,10 +27,10 @@ private _maxLength = abs ((_p2 select 1) - (_p1 select 1));
 private _direction = getDir _object;
 
 // Marker name unique to this object
-private _markerNameStr = format ["acex_fortify_marker_%1", _object];
+private _markerNameStr = format [QGVAR(marker_%1), _object];
 
 // Create marker, set alpha using global event
-private _marker = createMarker [_markerNameStr, _object];
+private _marker = createMarkerLocal [_markerNameStr, _object];
 _marker setMarkerShapeLocal "RECTANGLE";
 _marker setMarkerBrushLocal "SolidFull";
 _marker setMarkerSizeLocal [(_maxWidth / 2),(_maxLength / 2)];

--- a/addons/fortify/functions/fnc_deployConfirm.sqf
+++ b/addons/fortify/functions/fnc_deployConfirm.sqf
@@ -31,10 +31,11 @@ private _vectorDir = vectorDir _object;
 deleteVehicle _object;
 
 private _newObject = _typeOf createVehicle _posASL;
+_newObject setVariable [QGVAR(objectSide), _side, true];
 _newObject setPosASL _posASL;
 _newObject setVectorDirAndUp [_vectorDir, _vectorUp];
 
-// Server will use this event to run the jip compatible QGVAR(addActionToObject) event
+// Server will use this event to run the jip compatible QGVAR(addActionToObject) event and create the related map marker.
 [QGVAR(objectPlaced), [_unit, _side, _newObject]] call CBA_fnc_globalEvent;
 
 if (cba_events_control) then {

--- a/addons/fortify/initSettings.sqf
+++ b/addons/fortify/initSettings.sqf
@@ -9,6 +9,7 @@
         2
     ]
 ] call CBA_settings_fnc_init;
+
 [
     QGVAR(markObjectsOnMap),
     "LIST",

--- a/addons/fortify/initSettings.sqf
+++ b/addons/fortify/initSettings.sqf
@@ -8,7 +8,7 @@
         [LLSTRING(settingHintNone), LLSTRING(settingHintHasTool), LLSTRING(settingHintEveryone)],
         2
     ]
-] call CBA_settings_fnc_init;
+] call CBA_fnc_addSetting;
 
 [
     QGVAR(markObjectsOnMap),
@@ -23,4 +23,4 @@
     true,
     {},
     true
-] call CBA_settings_fnc_init;
+] call CBA_fnc_addSetting;

--- a/addons/fortify/initSettings.sqf
+++ b/addons/fortify/initSettings.sqf
@@ -9,3 +9,17 @@
         2
     ]
 ] call CBA_settings_fnc_init;
+[
+    QGVAR(markObjectsOnMap),
+    "LIST",
+    [LLSTRING(markObjectsOnMap), LLSTRING(markObjectsOnMapDesc)],
+    LLSTRING(settingsCategory),
+    [
+        [0, 1, 2],
+        [LLSTRING(markObjectsOnMapNone), LLSTRING(markObjectsOnMapFriendly), LLSTRING(markObjectsOnMapEveryone)],
+        1
+    ],
+    true,
+    {},
+    true
+] call CBA_settings_fnc_init;

--- a/addons/fortify/stringtable.xml
+++ b/addons/fortify/stringtable.xml
@@ -155,6 +155,21 @@
             <Russian>Показывать всегда</Russian>
             <Turkish>Her Zaman Göster</Turkish>
         </Key>
+        <Key ID="STR_ACEX_Fortify_markObjectsOnMap">
+            <English>Create map markers</English>
+        </Key>
+        <Key ID="STR_ACEX_Fortify_markObjectsOnMapDesc">
+            <English>Controls when budget update hints are shown</English>
+        </Key>
+        <Key ID="STR_ACEX_Fortify_markObjectsOnMapNone">
+            <English>Never</English>
+        </Key>
+        <Key ID="STR_ACEX_Fortify_markObjectsOnMapFriendly">
+            <English>Only for friendlies</English>
+        </Key>
+        <Key ID="STR_ACEX_Fortify_markObjectsOnMapEveryone">
+            <English>Show for everyone</English>
+        </Key>
         <Key ID="STR_ACEX_Fortify_small">
             <English>Small</English>
             <Polish>Małe</Polish>

--- a/addons/fortify/stringtable.xml
+++ b/addons/fortify/stringtable.xml
@@ -159,16 +159,16 @@
             <English>Create map markers</English>
         </Key>
         <Key ID="STR_ACEX_Fortify_markObjectsOnMapDesc">
-            <English>Controls when budget update hints are shown</English>
+            <English>Create map area markers akin to terrain buildings when an ACEX static object is placed.</English>
         </Key>
         <Key ID="STR_ACEX_Fortify_markObjectsOnMapNone">
             <English>Never</English>
         </Key>
         <Key ID="STR_ACEX_Fortify_markObjectsOnMapFriendly">
-            <English>Only for friendlies</English>
+            <English>For friendlies only</English>
         </Key>
         <Key ID="STR_ACEX_Fortify_markObjectsOnMapEveryone">
-            <English>Show for everyone</English>
+            <English>For everyone</English>
         </Key>
         <Key ID="STR_ACEX_Fortify_small">
             <English>Small</English>

--- a/addons/fortify/stringtable.xml
+++ b/addons/fortify/stringtable.xml
@@ -159,13 +159,13 @@
             <English>Create map markers</English>
         </Key>
         <Key ID="STR_ACEX_Fortify_markObjectsOnMapDesc">
-            <English>Create map area markers akin to terrain buildings when an ACEX static object is placed.</English>
+            <English>Create map markers that look like terrain buildings when static fortifications are placed</English>
         </Key>
         <Key ID="STR_ACEX_Fortify_markObjectsOnMapNone">
             <English>Never</English>
         </Key>
         <Key ID="STR_ACEX_Fortify_markObjectsOnMapFriendly">
-            <English>For friendlies only</English>
+            <English>For units friendly to the placer</English>
         </Key>
         <Key ID="STR_ACEX_Fortify_markObjectsOnMapEveryone">
             <English>For everyone</English>


### PR DESCRIPTION
**When merged this pull request will:**
- Add map markers to ACEX Fortify placed static objects
- Configurable via CBA: Always, Never, Only show markers for friendlies
- Removed with placed object deletion

![107410_20210420231932_1](https://user-images.githubusercontent.com/65898127/115471134-66652780-a22f-11eb-8a9d-e72d6cabb997.png)
![107410_20210420231937_1](https://user-images.githubusercontent.com/65898127/115471151-6bc27200-a22f-11eb-9d87-6536101da536.png)

